### PR TITLE
Changing order of tagging

### DIFF
--- a/deployment/action.yml
+++ b/deployment/action.yml
@@ -80,6 +80,11 @@ runs:
         fi
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
+    - name: Create Release
+      shell: bash
+      run: gh release create "v${{ env.RELEASE_VERSION }}" --generate-notes
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
     - name: Update version
       shell: bash
       run: |
@@ -88,10 +93,5 @@ runs:
           git commit -am "Beginning ${{env.NEXT_VERSION}} [skip ci]"
           git push --force
         fi
-      env:
-        GITHUB_TOKEN: ${{ inputs.github_token }}
-    - name: Create Release
-      shell: bash
-      run: gh release create "v${{ env.RELEASE_VERSION }}" --generate-notes
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}


### PR DESCRIPTION
<!--
  If this pull request addresses an issue, make sure your description includes "Resolves #xx", "Fixes #xx", or "Closes #xx".
  https://help.github.com/articles/closing-issues-using-keywords
-->

## Description

We are currently tagging the commit after the release. This change has the intent of tagging the exact commit of the release.
![Screenshot 2023-07-11 at 9 18 48 AM](https://github.com/flybits/actions/assets/1508397/a31e601d-d1da-4042-b94d-b5c6f2b97e7f)

### Checklist

  - [x] PR title is clear and describes the work
  - [x] Commit messages are self-explanatory and summarize the change

### Action

  - [ ] Tests are provided/updated for the new/existing action
  - [ ] The action maintainer in `CODEOWNERS` is updated
  - [ ] The `README.md` file for new/existing action is created/updated
