### PR TITLE
[PET-000] Change Hardcoded name of paths to variables

### DIFF
--- a/backend/build/action.yaml
+++ b/backend/build/action.yaml
@@ -95,16 +95,18 @@ runs:
         echo "base64OfImage=$(echo -n ${{ inputs.docker_repo }} | base64)"
         
         echo "DOCKERIMAGEFILE=`echo -n ./docker-$base64OfImage.tar`" >> $GITHUB_ENV
-        echo $DOCKERIMAGEFILE
+        echo "${{ env.DOCKERIMAGEFILE }}"
 
         echo "VERSIONFILE=`echo -n VERSION-$base64OfImage`" >> $GITHUB_ENV
+        echo "${{ env.VERSIONFILE }}"
         echo $VERSIONFILE
 
         echo "DOCKERVARNAME=`echo -n docker-image-$base64OfImage`" >> $GITHUB_ENV
-        echo $DOCKERVARNAME
+        echo "${{ env.DOCKERVARNAME }}"
+        echo "$DOCKERVARNAME"
 
         echo "VERSIONFILENAME=`echo -n version-from-build-$base64OfImage`" >> $GITHUB_ENV
-        echo $VERSIONFILENAME
+        echo "${{ env.VERSIONFILENAME }}"
 
     #Build Docker Image
     - name: Build Docker Image
@@ -125,7 +127,7 @@ runs:
     - uses: actions/upload-artifact@v4
       with:
         name: ${{ env.VERSIONFILENAME }}
-        path: $VERSIONFILE
+        path: ${{ env.VERSIONFILE }}
         retention-days: 5
 
     #Scan local Docker Image With Trivy

--- a/backend/build/action.yaml
+++ b/backend/build/action.yaml
@@ -99,7 +99,7 @@ runs:
         echo "DOCKERVARNAME=`echo -n docker-image-$base64OfImage`" >> $GITHUB_ENV
         echo "VERSIONFILENAME=`echo -n version-from-build-$base64OfImage`" >> $GITHUB_ENV
 
-        cp VERSION $VERSIONFILE
+        cp VERSION "$VERSIONFILE"
 
     #Build Docker Image
     - name: Build Docker Image

--- a/backend/build/action.yaml
+++ b/backend/build/action.yaml
@@ -99,7 +99,7 @@ runs:
         echo "DOCKERVARNAME=`echo -n docker-image-$base64OfImage`" >> $GITHUB_ENV
         echo "VERSIONFILENAME=`echo -n version-from-build-$base64OfImage`" >> $GITHUB_ENV
 
-        cp VERSION "$VERSIONFILE"
+        cp VERSION ${{ env.VERSIONFILE}}
 
     #Build Docker Image
     - name: Build Docker Image

--- a/backend/build/action.yaml
+++ b/backend/build/action.yaml
@@ -106,7 +106,7 @@ runs:
       shell: bash
       run: |
         docker image build --file ${{ inputs.docker_file }} --build-arg GITHUB_SSH_KEY="${{ inputs.ssh_git_key}}" --tag $TAG .
-        docker image save --output ./docker.tar $TAG
+        docker image save --output ${{ env.DOCKERIMAGEFILE }} $TAG
 
     #Save Artifact for Push Docker Job
     - uses: actions/upload-artifact@v4

--- a/backend/build/action.yaml
+++ b/backend/build/action.yaml
@@ -93,10 +93,19 @@ runs:
       shell: bash
       run: |
         echo "IMAGEBASE64=$(echo -n ${{ inputs.docker_repo }} | base64)"
-        echo "DockerImageFile=./docker-${{ env.IMAGEBASE64 }}.tar" >> $GITHUB_ENV
-        echo "VersionFile=VERSION-${{ env.IMAGEBASE64 }}" >> $GITHUB_ENV
-        echo "DockerVarName=docker-image-$IMAGEBASE64" >> $GITHUB_ENV
-        echo "VersionVarName=version-from-build-$IMAGEBASE64" >> $GITHUB_ENV
+        
+        echo "DockerImageFile=$(echo -n ./docker-$IMAGEBASE64.tar)" >> $GITHUB_ENV
+        echo $DockerImageFile
+
+        echo "VersionFile=$(echo -n VERSION-$IMAGEBASE64)" >> $GITHUB_ENV
+        cp VERSION $VersionFile
+        echo $VersionFile
+
+        echo "DockerVarName=$(echo -n docker-image-$IMAGEBASE64)" >> $GITHUB_ENV
+        echo $DockerVarName
+
+        echo "VersionVarName=$(echo -n version-from-build-$IMAGEBASE64)" >> $GITHUB_ENV
+        echo $VersionVarName
 
     #Build Docker Image
     - name: Build Docker Image

--- a/backend/build/action.yaml
+++ b/backend/build/action.yaml
@@ -92,40 +92,40 @@ runs:
     - name: Setup Paths
       shell: bash
       run: |
-        echo "IMAGEBASE64=$(echo -n ${{ inputs.docker_repo }} | base64)"
+        echo "base64OfImage=$(echo -n ${{ inputs.docker_repo }} | base64)"
         
-        echo "DockerImageFile=$(echo -n ./docker-$IMAGEBASE64.tar)" >> $GITHUB_ENV
-        echo $DockerImageFile
+        echo "DOCKERIMAGEFILE=$(echo -n ./docker-$base64OfImage.tar)" >> $GITHUB_ENV
+        echo $DOCKERIMAGEFILE
 
-        echo "VersionFile=$(echo -n VERSION-$IMAGEBASE64)" >> $GITHUB_ENV
-        echo $VersionFile
+        echo "VERSIONFILE=$(echo -n VERSION-$base64OfImage)" >> $GITHUB_ENV
+        echo $VERSIONFILE
 
-        echo "DockerVarName=$(echo -n docker-image-$IMAGEBASE64)" >> $GITHUB_ENV
-        echo $DockerVarName
+        echo "DOCKERVARNAME=$(echo -n docker-image-$base64OfImage)" >> $GITHUB_ENV
+        echo $DOCKERVARNAME
 
-        echo "VersionVarName=$(echo -n version-from-build-$IMAGEBASE64)" >> $GITHUB_ENV
-        echo $VersionVarName
+        echo "VERSIONFILENAME=$(echo -n version-from-build-$base64OfImage)" >> $GITHUB_ENV
+        echo $VERSIONFILENAME
 
     #Build Docker Image
     - name: Build Docker Image
       shell: bash
       run: |
-        echo $DockerImageFile
+        echo $DOCKERIMAGEFILE
         docker image build --file ${{ inputs.docker_file }} --build-arg GITHUB_SSH_KEY="${{ inputs.ssh_git_key}}" --tag $TAG .
-        docker image save --output $DockerImageFile $TAG
+        docker image save --output $DOCKERIMAGEFILE $TAG
 
     #Save Artifact for Push Docker Job
     - uses: actions/upload-artifact@v4
       with:
-        name: ${{ env.DockerVarName }}
-        path: ${{ env.DockerImageFile }}
+        name: ${{ env.DOCKERVARNAME }}
+        path: ${{ env.DOCKERIMAGEFILE }}
         retention-days: 5
     
     #Save Artifact for Push Docker Job
     - uses: actions/upload-artifact@v4
       with:
-        name: ${{ env.VersionVarName }}
-        path: $VersionFile
+        name: ${{ env.VERSIONFILENAME }}
+        path: $VERSIONFILE
         retention-days: 5
 
     #Scan local Docker Image With Trivy

--- a/backend/build/action.yaml
+++ b/backend/build/action.yaml
@@ -93,42 +93,32 @@ runs:
       shell: bash
       run: |
         echo "base64OfImage=$(echo -n ${{ inputs.docker_repo }} | base64)"
-        
-        echo "DOCKERIMAGEFILE=`echo -n ./docker-$base64OfImage.tar`" >> $GITHUB_ENV
-        echo "${{ env.DOCKERIMAGEFILE }}"
+        echo $base64OfImage
 
-        echo "VERSIONFILE=`echo -n VERSION-$base64OfImage`" >> $GITHUB_ENV
-        echo "${{ env.VERSIONFILE }}"
-        echo $VERSIONFILE
-
+        base64OfImage=`echo -n ${{ inputs.docker_repo }} | base64`
+        echo $base64OfImage
         echo -n docker-image-$base64OfImage
-        echo "DOCKERVARNAME=`echo -n docker-image-$base64OfImage`" >> $GITHUB_ENV
-        echo "${{ env.DOCKERVARNAME }}"
-        echo "$DOCKERVARNAME"
 
-        echo "VERSIONFILENAME=`echo -n version-from-build-$base64OfImage`" >> $GITHUB_ENV
-        echo "${{ env.VERSIONFILENAME }}"
 
     #Build Docker Image
     - name: Build Docker Image
       shell: bash
       run: |
-        echo $DOCKERIMAGEFILE
         docker image build --file ${{ inputs.docker_file }} --build-arg GITHUB_SSH_KEY="${{ inputs.ssh_git_key}}" --tag $TAG .
-        docker image save --output $DOCKERIMAGEFILE $TAG
+        docker image save --output ./docker.tar $TAG
 
     #Save Artifact for Push Docker Job
     - uses: actions/upload-artifact@v4
       with:
         name: ${{ env.DOCKERVARNAME }}
-        path: ${{ env.DOCKERIMAGEFILE }}
+        path: ./docker.tar
         retention-days: 5
     
     #Save Artifact for Push Docker Job
     - uses: actions/upload-artifact@v4
       with:
         name: ${{ env.VERSIONFILENAME }}
-        path: ${{ env.VERSIONFILE }}
+        path: VERSION
         retention-days: 5
 
     #Scan local Docker Image With Trivy

--- a/backend/build/action.yaml
+++ b/backend/build/action.yaml
@@ -65,6 +65,7 @@ runs:
         elif [[ ${{ inputs.type }} == "production" ]]; then
           VERSION=${VERSION/-0/}
         fi
+
         echo "TAG=${{ inputs.docker_repo }}:${VERSION}" >> $GITHUB_ENV
         echo "$VERSION" > VERSION
 
@@ -91,21 +92,24 @@ runs:
     - name: Build Docker Image
       shell: bash
       run: |
+        echo "IMAGEBASE64=$(echo -n ${{ inputs.docker_repo }} | base64)"
+        DOCKERPATH = "./docker-${{ env.DOCKERPATH }}.tar" >> $GITHUB_ENV
+        VERSIONPATH = "VERSION-${{ env.DOCKERPATH }}" >> $GITHUB_ENV
         docker image build --file ${{ inputs.docker_file }} --build-arg GITHUB_SSH_KEY="${{ inputs.ssh_git_key}}" --tag $TAG .
-        docker image save --output ./docker.tar $TAG
+        docker image save --output $DOCKERPATH $TAG
 
     #Save Artifact for Push Docker Job
     - uses: actions/upload-artifact@v4
       with:
         name: docker-image
-        path: ./docker.tar
+        path: ${{ env.DOCKERPATH }}
         retention-days: 5
     
     #Save Artifact for Push Docker Job
     - uses: actions/upload-artifact@v4
       with:
         name: version-from-build
-        path: VERSION
+        path: $VERSIONPATH
         retention-days: 5
 
     #Scan local Docker Image With Trivy

--- a/backend/build/action.yaml
+++ b/backend/build/action.yaml
@@ -93,13 +93,14 @@ runs:
       shell: bash
       run: |
         base64OfImage=`echo -n ${{ inputs.docker_repo }} | base64`
+        versionFile=`echo -n VERSION-$base64OfImage`
         
         echo "DOCKERIMAGEFILE=`echo -n ./docker-$base64OfImage.tar`" >> $GITHUB_ENV
-        echo "VERSIONFILE=`echo -n VERSION-$base64OfImage`" >> $GITHUB_ENV
+        echo "VERSIONFILE=`echo -n $versionFile`" >> $GITHUB_ENV
         echo "DOCKERVARNAME=`echo -n docker-image-$base64OfImage`" >> $GITHUB_ENV
         echo "VERSIONFILENAME=`echo -n version-from-build-$base64OfImage`" >> $GITHUB_ENV
 
-        cp VERSION ${{ env.VERSIONFILE}}
+        cp VERSION $versionFile
 
     #Build Docker Image
     - name: Build Docker Image

--- a/backend/build/action.yaml
+++ b/backend/build/action.yaml
@@ -94,9 +94,9 @@ runs:
       run: |
         echo "IMAGEBASE64=$(echo -n ${{ inputs.docker_repo }} | base64)"
         DOCKERPATH=$(echo "./docker-${{ env.IMAGEBASE64 }}.tar") >> $GITHUB_ENV
-        VERSIONPATH =$(echo "VERSION-${{ env.IMAGEBASE64 }}") >> $GITHUB_ENV
-        DOCKERVARNAME =$(echo "docker-image-$IMAGEBASE64") >> $GITHUB_ENV
-        VERSIONVARNAME =$(echo "version-from-build-$IMAGEBASE64") >> $GITHUB_ENV
+        VERSIONPATH=$(echo "VERSION-${{ env.IMAGEBASE64 }}") >> $GITHUB_ENV
+        DOCKERVARNAME=$(echo "docker-image-$IMAGEBASE64") >> $GITHUB_ENV
+        VERSIONVARNAME=$(echo "version-from-build-$IMAGEBASE64") >> $GITHUB_ENV
 
     #Build Docker Image
     - name: Build Docker Image

--- a/backend/build/action.yaml
+++ b/backend/build/action.yaml
@@ -93,8 +93,8 @@ runs:
       shell: bash
       run: |
         echo "IMAGEBASE64=$(echo -n ${{ inputs.docker_repo }} | base64)"
-        DOCKERPATH = "./docker-${{ env.DOCKERPATH }}.tar" >> $GITHUB_ENV
-        VERSIONPATH = "VERSION-${{ env.DOCKERPATH }}" >> $GITHUB_ENV
+        DOCKERPATH = "./docker-${{ env.IMAGEBASE64 }}.tar" >> $GITHUB_ENV
+        VERSIONPATH = "VERSION-${{ env.IMAGEBASE64 }}" >> $GITHUB_ENV
         DOCKERVARNAME = "docker-image-$IMAGEBASE64" >> $GITHUB_ENV
         VERSIONVARNAME = "version-from-build-$IMAGEBASE64" >> $GITHUB_ENV
 

--- a/backend/build/action.yaml
+++ b/backend/build/action.yaml
@@ -92,13 +92,12 @@ runs:
     - name: Setup Paths
       shell: bash
       run: |
-        echo "base64OfImage=$(echo -n ${{ inputs.docker_repo }} | base64)"
-        echo $base64OfImage
-
         base64OfImage=`echo -n ${{ inputs.docker_repo }} | base64`
-        echo $base64OfImage
-        echo -n docker-image-$base64OfImage
-
+        
+        echo "DOCKERIMAGEFILE=`echo -n ./docker-$base64OfImage.tar`" >> $GITHUB_ENV
+        echo "VERSIONFILE=`echo -n VERSION-$base64OfImage`" >> $GITHUB_ENV
+        echo "DOCKERVARNAME=`echo -n docker-image-$base64OfImage`" >> $GITHUB_ENV
+        echo "VERSIONFILENAME=`echo -n version-from-build-$base64OfImage`" >> $GITHUB_ENV
 
     #Build Docker Image
     - name: Build Docker Image
@@ -111,14 +110,14 @@ runs:
     - uses: actions/upload-artifact@v4
       with:
         name: ${{ env.DOCKERVARNAME }}
-        path: ./docker.tar
+        path: ${{ env.DOCKERIMAGEFILE }}
         retention-days: 5
     
     #Save Artifact for Push Docker Job
     - uses: actions/upload-artifact@v4
       with:
         name: ${{ env.VERSIONFILENAME }}
-        path: VERSION
+        path: ${{ env.VERSIONFILE }}
         retention-days: 5
 
     #Scan local Docker Image With Trivy

--- a/backend/build/action.yaml
+++ b/backend/build/action.yaml
@@ -93,30 +93,31 @@ runs:
       shell: bash
       run: |
         echo "IMAGEBASE64=$(echo -n ${{ inputs.docker_repo }} | base64)"
-        DOCKERPATH=$(echo "./docker-${{ env.IMAGEBASE64 }}.tar") >> $GITHUB_ENV
-        VERSIONPATH=$(echo "VERSION-${{ env.IMAGEBASE64 }}") >> $GITHUB_ENV
-        DOCKERVARNAME=$(echo "docker-image-$IMAGEBASE64") >> $GITHUB_ENV
-        VERSIONVARNAME=$(echo "version-from-build-$IMAGEBASE64") >> $GITHUB_ENV
+        echo "DockerImageFile=./docker-${{ env.IMAGEBASE64 }}.tar" >> $GITHUB_ENV
+        echo "VersionFile=VERSION-${{ env.IMAGEBASE64 }}" >> $GITHUB_ENV
+        echo "DockerVarName=docker-image-$IMAGEBASE64" >> $GITHUB_ENV
+        echo "VersionVarName=version-from-build-$IMAGEBASE64" >> $GITHUB_ENV
 
     #Build Docker Image
     - name: Build Docker Image
       shell: bash
       run: |
+        echo $DockerImageFile
         docker image build --file ${{ inputs.docker_file }} --build-arg GITHUB_SSH_KEY="${{ inputs.ssh_git_key}}" --tag $TAG .
-        docker image save --output $DOCKERPATH $TAG
+        docker image save --output $DockerImageFile $TAG
 
     #Save Artifact for Push Docker Job
     - uses: actions/upload-artifact@v4
       with:
-        name: ${{ env.DOCKERVARNAME }}
-        path: ${{ env.DOCKERPATH }}
+        name: ${{ env.DockerVarName }}
+        path: ${{ env.DockerImageFile }}
         retention-days: 5
     
     #Save Artifact for Push Docker Job
     - uses: actions/upload-artifact@v4
       with:
-        name: ${{ env.VERSIONVARNAME }}
-        path: $VERSIONPATH
+        name: ${{ env.VersionVarName }}
+        path: $VersionFile
         retention-days: 5
 
     #Scan local Docker Image With Trivy

--- a/backend/build/action.yaml
+++ b/backend/build/action.yaml
@@ -89,6 +89,10 @@ runs:
         trivy config --exit-code 1 --severity HIGH,CRITICAL ${{ inputs.docker_file }}
 
     #Setup Paths
+    #This is needed because its possible there are cases where multiple actions need to be run such as auth;
+    #Auth has two images that get deployed one for the Auth service and one for the Auth User Deletion cronjob
+    #In order to avoid collisions between the two jobs we need to have different names for the files that get 
+    #uploaded.
     - name: Setup Paths
       shell: bash
       run: |

--- a/backend/build/action.yaml
+++ b/backend/build/action.yaml
@@ -101,6 +101,7 @@ runs:
         echo "${{ env.VERSIONFILE }}"
         echo $VERSIONFILE
 
+        echo -n docker-image-$base64OfImage
         echo "DOCKERVARNAME=`echo -n docker-image-$base64OfImage`" >> $GITHUB_ENV
         echo "${{ env.DOCKERVARNAME }}"
         echo "$DOCKERVARNAME"

--- a/backend/build/action.yaml
+++ b/backend/build/action.yaml
@@ -93,10 +93,10 @@ runs:
       shell: bash
       run: |
         echo "IMAGEBASE64=$(echo -n ${{ inputs.docker_repo }} | base64)"
-        DOCKERPATH = "./docker-${{ env.IMAGEBASE64 }}.tar" >> $GITHUB_ENV
-        VERSIONPATH = "VERSION-${{ env.IMAGEBASE64 }}" >> $GITHUB_ENV
-        DOCKERVARNAME = "docker-image-$IMAGEBASE64" >> $GITHUB_ENV
-        VERSIONVARNAME = "version-from-build-$IMAGEBASE64" >> $GITHUB_ENV
+        DOCKERPATH=$(echo "./docker-${{ env.IMAGEBASE64 }}.tar") >> $GITHUB_ENV
+        VERSIONPATH =$(echo "VERSION-${{ env.IMAGEBASE64 }}") >> $GITHUB_ENV
+        DOCKERVARNAME =$(echo "docker-image-$IMAGEBASE64") >> $GITHUB_ENV
+        VERSIONVARNAME =$(echo "version-from-build-$IMAGEBASE64") >> $GITHUB_ENV
 
     #Build Docker Image
     - name: Build Docker Image

--- a/backend/build/action.yaml
+++ b/backend/build/action.yaml
@@ -88,27 +88,34 @@ runs:
         trivy fs --exit-code 1 --severity HIGH,CRITICAL --no-progress .
         trivy config --exit-code 1 --severity HIGH,CRITICAL ${{ inputs.docker_file }}
 
-    #Build Docker Image
-    - name: Build Docker Image
+    #Setup Paths
+    - name: Setup Paths
       shell: bash
       run: |
         echo "IMAGEBASE64=$(echo -n ${{ inputs.docker_repo }} | base64)"
         DOCKERPATH = "./docker-${{ env.DOCKERPATH }}.tar" >> $GITHUB_ENV
         VERSIONPATH = "VERSION-${{ env.DOCKERPATH }}" >> $GITHUB_ENV
+        DOCKERVARNAME = "docker-image-$IMAGEBASE64" >> $GITHUB_ENV
+        VERSIONVARNAME = "version-from-build-$IMAGEBASE64" >> $GITHUB_ENV
+
+    #Build Docker Image
+    - name: Build Docker Image
+      shell: bash
+      run: |
         docker image build --file ${{ inputs.docker_file }} --build-arg GITHUB_SSH_KEY="${{ inputs.ssh_git_key}}" --tag $TAG .
         docker image save --output $DOCKERPATH $TAG
 
     #Save Artifact for Push Docker Job
     - uses: actions/upload-artifact@v4
       with:
-        name: docker-image
+        name: ${{ env.DOCKERVARNAME }}
         path: ${{ env.DOCKERPATH }}
         retention-days: 5
     
     #Save Artifact for Push Docker Job
     - uses: actions/upload-artifact@v4
       with:
-        name: version-from-build
+        name: ${{ env.VERSIONVARNAME }}
         path: $VERSIONPATH
         retention-days: 5
 

--- a/backend/build/action.yaml
+++ b/backend/build/action.yaml
@@ -99,6 +99,8 @@ runs:
         echo "DOCKERVARNAME=`echo -n docker-image-$base64OfImage`" >> $GITHUB_ENV
         echo "VERSIONFILENAME=`echo -n version-from-build-$base64OfImage`" >> $GITHUB_ENV
 
+        cp VERSION $VERSIONFILE
+
     #Build Docker Image
     - name: Build Docker Image
       shell: bash

--- a/backend/build/action.yaml
+++ b/backend/build/action.yaml
@@ -94,16 +94,16 @@ runs:
       run: |
         echo "base64OfImage=$(echo -n ${{ inputs.docker_repo }} | base64)"
         
-        echo "DOCKERIMAGEFILE=$(echo -n ./docker-$base64OfImage.tar)" >> $GITHUB_ENV
+        echo "DOCKERIMAGEFILE=`echo -n ./docker-$base64OfImage.tar`" >> $GITHUB_ENV
         echo $DOCKERIMAGEFILE
 
-        echo "VERSIONFILE=$(echo -n VERSION-$base64OfImage)" >> $GITHUB_ENV
+        echo "VERSIONFILE=`echo -n VERSION-$base64OfImage`" >> $GITHUB_ENV
         echo $VERSIONFILE
 
-        echo "DOCKERVARNAME=$(echo -n docker-image-$base64OfImage)" >> $GITHUB_ENV
+        echo "DOCKERVARNAME=`echo -n docker-image-$base64OfImage`" >> $GITHUB_ENV
         echo $DOCKERVARNAME
 
-        echo "VERSIONFILENAME=$(echo -n version-from-build-$base64OfImage)" >> $GITHUB_ENV
+        echo "VERSIONFILENAME=`echo -n version-from-build-$base64OfImage`" >> $GITHUB_ENV
         echo $VERSIONFILENAME
 
     #Build Docker Image

--- a/backend/build/action.yaml
+++ b/backend/build/action.yaml
@@ -98,7 +98,6 @@ runs:
         echo $DockerImageFile
 
         echo "VersionFile=$(echo -n VERSION-$IMAGEBASE64)" >> $GITHUB_ENV
-        cp VERSION $VersionFile
         echo $VersionFile
 
         echo "DockerVarName=$(echo -n docker-image-$IMAGEBASE64)" >> $GITHUB_ENV

--- a/backend/build/action.yaml
+++ b/backend/build/action.yaml
@@ -17,6 +17,10 @@ inputs:
   docker_repo:
     description: The repository where the docker image should be saved. Format is {organization}/{repository}
     required: true
+  docker_file:
+    description: The dockerfile to process.
+    required: false
+    default: Dockerfile
   who_trigger:
     description: "Who trigger the pipeline"
     required: true
@@ -81,13 +85,13 @@ runs:
       shell: bash
       run: |
         trivy fs --exit-code 1 --severity HIGH,CRITICAL --no-progress .
-        trivy config --exit-code 1 --severity HIGH,CRITICAL Dockerfile
+        trivy config --exit-code 1 --severity HIGH,CRITICAL ${{ inputs.docker_file }}
 
     #Build Docker Image
     - name: Build Docker Image
       shell: bash
       run: |
-        docker image build --file Dockerfile --build-arg GITHUB_SSH_KEY="${{ inputs.ssh_git_key}}" --tag $TAG .
+        docker image build --file ${{ inputs.docker_file }} --build-arg GITHUB_SSH_KEY="${{ inputs.ssh_git_key}}" --tag $TAG .
         docker image save --output ./docker.tar $TAG
 
     #Save Artifact for Push Docker Job

--- a/backend/push/action.yaml
+++ b/backend/push/action.yaml
@@ -62,6 +62,10 @@ runs:
         ssh-add - <<< "${{ inputs.ssh_git_key }}"
 
     #Setup Paths
+    #This is needed because its possible there are cases where multiple actions need to be run such as auth;
+    #Auth has two images that get deployed one for the Auth service and one for the Auth User Deletion cronjob
+    #In order to avoid collisions between the two jobs we need to have different names for the files that get 
+    #uploaded.
     - name: Setup Paths
       shell: bash
       run: |

--- a/backend/push/action.yaml
+++ b/backend/push/action.yaml
@@ -61,23 +61,33 @@ runs:
         ssh-agent -a $SSH_AUTH_SOCK > /dev/null
         ssh-add - <<< "${{ inputs.ssh_git_key }}"
 
+    #Setup Paths
+    - name: Setup Paths
+      shell: bash
+      run: |
+        echo "IMAGEBASE64=$(echo -n ${{ inputs.docker_repo }} | base64)"
+        DOCKERPATH=$(echo "./docker-${{ env.IMAGEBASE64 }}.tar") >> $GITHUB_ENV
+        VERSIONPATH =$(echo "VERSION-${{ env.IMAGEBASE64 }}") >> $GITHUB_ENV
+        DOCKERVARNAME =$(echo "docker-image-$IMAGEBASE64") >> $GITHUB_ENV
+        VERSIONVARNAME =$(echo "version-from-build-$IMAGEBASE64") >> $GITHUB_ENV
+
     #The coorsponding action for storing this artifact can be found in backend/build/action.yaml under "Save Artifact for Push Docker Job"
     - uses: actions/download-artifact@v4
       with:
-        name: docker-image
+        name: ${{ env.DOCKERVARNAME }}
         path: /tmp
 
     #The coorsponding action for storing this artifact can be found in backend/build/action.yaml under "Save Artifact for Push Docker Job"
     - uses: actions/download-artifact@v4
       with:
-        name: version-from-build
+        name: ${{ env.VERSIONVARNAME }}
         path: /tmp
 
     #Expose Version of Image
     - name: Expose Version As Environment Variable
       shell: bash
       run: |
-        VERSION=$(cat /tmp/VERSION)
+        VERSION=$(cat /tmp/$VERSIONPATH)
         echo "VERSION: $VERSION"
         echo "TAG=${{ inputs.docker_repo }}:${VERSION}" >> $GITHUB_ENV
     
@@ -85,7 +95,7 @@ runs:
     - name: Push Docker Image
       shell: bash
       run: |
-        docker image load --input /tmp/docker.tar
+        docker image load --input /tmp/${{ env.DOCKERPATH }}
         docker login --username ${{ inputs.docker_username }} --password ${{ inputs.docker_password }}
         docker push $TAG
 

--- a/backend/push/action.yaml
+++ b/backend/push/action.yaml
@@ -65,11 +65,12 @@ runs:
     - name: Setup Paths
       shell: bash
       run: |
-        echo "IMAGEBASE64=$(echo -n ${{ inputs.docker_repo }} | base64)"
-        DOCKERPATH=$(echo "./docker-${{ env.IMAGEBASE64 }}.tar") >> $GITHUB_ENV
-        VERSIONPATH =$(echo "VERSION-${{ env.IMAGEBASE64 }}") >> $GITHUB_ENV
-        DOCKERVARNAME =$(echo "docker-image-$IMAGEBASE64") >> $GITHUB_ENV
-        VERSIONVARNAME =$(echo "version-from-build-$IMAGEBASE64") >> $GITHUB_ENV
+        base64OfImage=`echo -n ${{ inputs.docker_repo }} | base64`
+        
+        echo "DOCKERIMAGEFILE=`echo -n docker-$base64OfImage.tar`" >> $GITHUB_ENV
+        echo "VERSIONFILE=`echo -n VERSION-$base64OfImage`" >> $GITHUB_ENV
+        echo "DOCKERVARNAME=`echo -n docker-image-$base64OfImage`" >> $GITHUB_ENV
+        echo "VERSIONFILENAME=`echo -n version-from-build-$base64OfImage`" >> $GITHUB_ENV
 
     #The coorsponding action for storing this artifact can be found in backend/build/action.yaml under "Save Artifact for Push Docker Job"
     - uses: actions/download-artifact@v4
@@ -80,14 +81,14 @@ runs:
     #The coorsponding action for storing this artifact can be found in backend/build/action.yaml under "Save Artifact for Push Docker Job"
     - uses: actions/download-artifact@v4
       with:
-        name: ${{ env.VERSIONVARNAME }}
+        name: ${{ env.VERSIONFILENAME }}
         path: /tmp
 
     #Expose Version of Image
     - name: Expose Version As Environment Variable
       shell: bash
       run: |
-        VERSION=$(cat /tmp/$VERSIONPATH)
+        VERSION=$(cat /tmp/$VERSIONFILE)
         echo "VERSION: $VERSION"
         echo "TAG=${{ inputs.docker_repo }}:${VERSION}" >> $GITHUB_ENV
     
@@ -95,7 +96,7 @@ runs:
     - name: Push Docker Image
       shell: bash
       run: |
-        docker image load --input /tmp/${{ env.DOCKERPATH }}
+        docker image load --input /tmp/${{ env.DOCKERIMAGEFILE }}
         docker login --username ${{ inputs.docker_username }} --password ${{ inputs.docker_password }}
         docker push $TAG
 


### PR DESCRIPTION
<!--
  If this pull request addresses an issue, make sure your description includes "Resolves #xx", "Fixes #xx", or "Closes #xx".
  https://help.github.com/articles/closing-issues-using-keywords
-->
## Description
So we came across a problem with Auth service which has 2 separate deployments; one for the auth service and one for the auth user deletion cronjob. The problem that arose was there was collision when uploading files from the build steps as there was now 2 build steps and the VERSION file and docker.tar were colliding from each build and one of the builds was failing. 

I did successfully test this process and an example can be seen here: https://github.com/flybits/auth/actions/runs/9687497271 

To summarize the change we are changing the name of the files that was being uploaded and passed from job to job. The file names are changing by appending the base64 of the repo name: so turning flybits/auth for example into Zmx5Yml0cy9hdXRo and therefore the files would be names VERSION-Zmx5Yml0cy9hdXRo and docker-Zmx5Yml0cy9hdXRo.tar. This works because regardless of the job that is running when uploading to DockerHub the repo name needs to be unique even if its the same action that is running.

### Checklist

  - [ ] PR title is clear and describes the work
  - [ ] Commit messages are self-explanatory and summarize the change

### Action

  - [ ] Tests are provided/updated for the new/existing action
  - [ ] The action maintainer in `CODEOWNERS` is updated
  - [ ] The `README.md` file for new/existing action is created/updated
