### PR TITLE
Expose input variable to specify which node version to use

### DIFF
--- a/frontend/node-npm/install/action.yml
+++ b/frontend/node-npm/install/action.yml
@@ -6,6 +6,11 @@ inputs:
     description: 'A token used for accessing private NPM packages (published by Flybits Inc.)'
     required: true
 
+  node-version:
+    description: 'The version of Node to use'
+    default: 'lts/*'
+    required: false
+
   slack-bot-token:
     description: 'A bot token to publish a message on Slack'
     required: true
@@ -30,7 +35,7 @@ runs:
     - name: Install node
       uses: actions/setup-node@v4
       with:
-        node-version: 'lts/Iron'
+        node-version: ${{ inputs.node-version }}
         cache: 'npm'
 
     - name: Restore packages from cache


### PR DESCRIPTION
## Description
This PR updates Front-End team's node-npm/install action to allow user to specify which version of node to use for the workflow.

### Checklist

  - [X] PR title is clear and describes the work
  - [X] Commit messages are self-explanatory and summarize the change
