### PR TITLE
Add Action To Delete Docker Hub Images

### DIFF
--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -28,7 +28,7 @@ runs:
       shell: bash
       run: |
         echo "Authenticating with Docker Hub..."
-        TOKEN=$(curl -s -u "${{ inputs.docker_username }}:${{ inputs.docker_password }}" "https://hub.docker.com/v2/users/login/" | jq -r '.token')
+        TOKEN=$(curl -s -X POST -u "${{ inputs.docker_username }}:${{ inputs.docker_password }}" "https://hub.docker.com/v2/users/login/" | jq -r '.token')
         echo "DOCKER_TOKEN=$TOKEN" >> $GITHUB_ENV
 
     - name: Cleanup Repository Images

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -36,7 +36,7 @@ runs:
         echo "Username: ${{ inputs.docker_username }}"
         username=${{ inputs.docker_username }}
         echo "Password: [REDACTED]"  # Do not echo secrets directly!
-        echo "Token length: ${#DOCKER_TOKEN}"  # Check token is being set
+        echo "Token length: ${#TOKEN}"  # Check token is being set
         echo "Username length: ${#username}"  # Check token is being set
 
     - name: Cleanup Repository Images

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -76,6 +76,7 @@ runs:
 
           # Get all image tags that match the staging regex
           TAGS_STAGING=$(echo "$response_body" | jq -r '.results[] | select(.name | test("-ecdf6e4$")) | .name')
+          echo "TAGS STAGING TO DELETE: $TAGS_STAGING"
 
           # Get tags to delete from TAGS_DEV (skip the first N tags)
           TAGS_DEV_TO_DELETE=$(echo "$TAGS_DEV" | tail -n +$((KEEP_LATEST + 1)))

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -33,11 +33,11 @@ runs:
         TOKEN=$(echo "$response" | jq -r '.token')
         echo "DOCKER_TOKEN=$TOKEN" >> $GITHUB_ENV
 
-        # Extract and decode the payload
-        PAYLOAD=$(echo "$DOCKER_TOKEN" | cut -d '.' -f2 | base64 -d 2>/dev/null)
-
-        # Print the payload
-        echo "Payload is: $PAYLOAD"
+        echo "Username: ${{ secrets.docker_username }}"
+        username=${{ secrets.docker_username }}
+        echo "Password: [REDACTED]"  # Do not echo secrets directly!
+        echo "Token length: ${#DOCKER_TOKEN}"  # Check token is being set
+        echo "Username length: ${#username}"  # Check token is being set
 
     - name: Cleanup Repository Images
       shell: bash

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -75,7 +75,7 @@ runs:
           TAGS_DEV=$(echo "$response_body" | jq -r '.results[] | select(.name | endswith(".dev")) | .name')
 
           # Get all image tags that match the staging regex
-          TAGS_STAGING=$(echo "$response_body" | jq -r '.results[] | select(.name | test("-[a-zA-Z0-9]{7}")) | .name')
+          TAGS_STAGING=$(echo "$response_body" | jq -r '.results[] | select(.name | test("-[a-zA-Z0-9]{7}$")) | .name')
          
           # Get tags to delete from TAGS_DEV (skip the first N tags)
           TAGS_DEV_TO_DELETE=$(echo "$TAGS_DEV" | tail -n +$((KEEP_LATEST + 1)))

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -20,17 +20,20 @@ runs:
   using: "composite"
   steps:
     - name: Install Dependencies
+      shell: bash
       run: |
         sudo apt-get update
         sudo apt-get install -y jq
 
     - name: Authenticate with Docker Hub
+      shell: bash
       run: |
         echo "Authenticating with Docker Hub..."
         TOKEN=$(curl -s -u "${{ inputs.docker_username }}:${{ inputs.docker_password }}" "https://hub.docker.com/v2/users/login/" | jq -r '.token')
         echo "DOCKER_TOKEN=$TOKEN" >> $GITHUB_ENV
 
     - name: Cleanup Repository Images
+      shell: bash
       env:
         DOCKER_TOKEN: ${{ env.DOCKER_TOKEN }}
       run: |

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -24,20 +24,20 @@ runs:
       run: |
         sudo apt-get install -y jq
 
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ inputs.docker_username }}
+        password: ${{ inputs.docker_password }}
+
     - name: Authenticate with Docker Hub
       shell: bash
       run: |
         echo "Authenticating with Docker Hub..."
-        response=$(curl -s -X POST -H "Content-Type: application/json" -d "{\"username\":\"${{ inputs.docker_username }}\",\"password\":\"${{ inputs.docker_password }}\"}" "https://hub.docker.com/v2/users/login/")
-        echo "Authentication Response: $response"
-        TOKEN=$(echo "$response" | jq -r '.token')
-        echo "DOCKER_TOKEN=$TOKEN" >> $GITHUB_ENV
-
-        echo "Username: ${{ inputs.docker_username }}"
-        username=${{ inputs.docker_username }}
-        echo "Password: [REDACTED]"  # Do not echo secrets directly!
-        echo "Token length: ${#TOKEN}"  # Check token is being set
-        echo "Username length: ${#username}"  # Check token is being set
+        # Decode the Docker config to extract the token
+        TOKEN=$(jq -r '.auths["https://index.docker.io/v1/"].auth' ~/.docker/config.json | base64 -d | cut -d':' -f2)
+        echo "DOCKER_TOKEN=${TOKEN}" >> $GITHUB_ENV
+        
 
     - name: Cleanup Repository Images
       shell: bash
@@ -80,7 +80,7 @@ runs:
             deleteUrl=https://hub.docker.com/v2/repositories/$REPO/tags/$TAG
             echo "Deleting tag: $TAG - $deleteUrl"
             
-            response=$(curl -v -s -X DELETE -H "Authorization: Bearer $DOCKER_TOKEN" -o response.txt -w "%{http_code}" "$deleteUrl")
+            response=$(curl -s -X DELETE -H "Authorization: Bearer $DOCKER_TOKEN" -o response.txt -w "%{http_code}" "$deleteUrl")
             http_code="${response: -3}"
             if [[ $http_code -ne 204 ]]; then
               response_body=$(<response.txt)

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -30,7 +30,7 @@ runs:
         echo "Authenticating with Docker Hub..."
         response=$(curl -s -X POST -H "Content-Type: application/json" -d "{\"username\":\"${{ inputs.docker_username }}\",\"password\":\"${{ inputs.docker_password }}\"}" "https://hub.docker.com/v2/users/login/")
         echo "Authentication Response: $response"
-        TOKEN=$("$response" | jq -r '.token')
+        TOKEN=$(echo "$response" | jq -r '.token')
         echo "DOCKER_TOKEN=$TOKEN" >> $GITHUB_ENV
 
     - name: Cleanup Repository Images

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -49,7 +49,7 @@ runs:
           
           # Fetch all tags for the repository
           url="https://hub.docker.com/v2/repositories/$REPO/tags?page=$CURRENT_PAGE&page_size=100"
-         echo "Fetching page $CURRENT_PAGE for tags in $REPO - $url"
+          echo "Fetching page $CURRENT_PAGE for tags in $REPO - $url"
 
           response=$(curl -s -H "Authorization: JWT $DOCKER_TOKEN" -o response.txt -w "%{http_code}" "$url")
           # Split the status code and response
@@ -62,8 +62,8 @@ runs:
 
           TAGS=$(echo "$response_body" | jq -r '.results[] | select(.name | endswith(".dev")) | .name')
           if [[ -z "$TAGS" ]]; then
-              echo "No Tags found."
-              exit 1
+            echo "No Tags found."
+            exit 1
           fi
            
           # Get tags to delete (skip the first N tags)
@@ -71,9 +71,10 @@ runs:
 
           # Loop through tags to delete
           for TAG in $TAGS_TO_DELETE; do
-            echo "Deleting tag: $TAG - https://hub.docker.com/v2/repositories/$REPO/tags/$TAG"
+            deleteUrl=https://hub.docker.com/v2/repositories/$REPO/tags/$TAG
+            echo "Deleting tag: $TAG - $deleteUrl"
 
-            response=$(curl -X DELETE -H "Authorization: JWT $DOCKER_TOKEN" -o response.txt -w "%{http_code}" "https://hub.docker.com/v2/repositories/$REPO/tags/$TAG")
+            response=$(curl -s -X DELETE -H "Authorization: JWT $DOCKER_TOKEN" -o response.txt -w "%{http_code}" "$deleteUrl")
             http_code="${response: -3}"
             if [[ $http_code -ne 204 ]]; then
               response_body=$(<response.txt)

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -24,6 +24,11 @@ runs:
       run: |
         sudo apt-get install -y jq
 
+     - name: Inputs validation
+      shell: bash
+      run: |
+        [[ "${{ inputs.keep_latest }}"  -ge 1 ]] || { echo "keep_latest must be at least 1" ; exit 1; }
+
     - name: Log in to Docker Hub
       uses: docker/login-action@v3
       with:
@@ -33,7 +38,6 @@ runs:
     - name: Retrieving Docker JWT
       shell: bash
       run: |
-        echo "Authenticating with Docker Hub..."
         # Decode the Docker config to extract the token
         TOKEN=$(jq -r '.auths["https://index.docker.io/v1/"].auth' ~/.docker/config.json | base64 -d | cut -d':' -f2)
         echo "DOCKER_TOKEN=${TOKEN}" >> $GITHUB_ENV
@@ -56,16 +60,20 @@ runs:
           url="https://hub.docker.com/v2/repositories/$REPO/tags?page=$CURRENT_PAGE&page_size=100"
           echo "Fetching page $CURRENT_PAGE for tags in $REPO - $url"
 
+          # Get the response and the http code associated to the response
           response=$(curl -s -H "Authorization: JWT $DOCKER_TOKEN" -o response.txt -w "%{http_code}" "$url")
           
-          # Split the status code and response if status code is not 200 exit ungracefully
+          # Split the status code and response.
           http_code="${response: -3}"
           response_body=$(<response.txt)
+
+          # If status code is 404 it means we have reached the end of the list so we can exit the loop and the job will be completed
           if [[ $http_code -eq 404 ]]; then
             echo "Could not find object so most likely we have reached the end - $response_body ..."
             break
           fi
 
+          # If status code is not 200 exit ungracefully.
           if [[ $http_code -ne 200 ]]; then
             echo "Request failed - $response_body ..."
             exit 1
@@ -88,11 +96,14 @@ runs:
 
           # Loop through tags to delete
           for TAG in $TAGS_TO_DELETE; do
+            
             deleteUrl=https://hub.docker.com/v2/repositories/$REPO/tags/$TAG
             echo "Deleting tag: $TAG - $deleteUrl"
             
             response=$(curl -s -X DELETE -H "Authorization: Bearer $DOCKER_TOKEN" -o response.txt -w "%{http_code}" "$deleteUrl")
             http_code="${response: -3}"
+            
+            # If the response is not 204 it means that something went wrong and exit ungracefully
             if [[ $http_code -ne 204 ]]; then
               response_body=$(<response.txt)
               echo "Deleting $TAG Request failed $http_code ... $response_body"
@@ -100,11 +111,13 @@ runs:
             fi
           done
 
+          # If there are no more pages to iterate through exit the loop and the job should be completed successfully
           if [[ "$next" == "null" ]]; then
             echo "Exiting paging loop for $REPO..."
             break
           fi
 
+          #Update pages and set KEEP_LATEST to 0 as for pages > 1 we do not want to keep any values
           KEEP_LATEST=0
           ((CURRENT_PAGE++))
         done

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -60,7 +60,7 @@ runs:
             exit 1
           fi
 
-          TAGS=$(echo "$response_body" | jq -r '.results[] | select(.name | endswith(".dev")) | .name' | sort -r)
+          TAGS=$(echo "$response_body" | jq -r '.results[] | select(.name | endswith(".dev")) | .name')
           if [[ -z "$TAGS" ]]; then
               echo "No Tags found."
               exit 1

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -33,8 +33,8 @@ runs:
         TOKEN=$(echo "$response" | jq -r '.token')
         echo "DOCKER_TOKEN=$TOKEN" >> $GITHUB_ENV
 
-        echo "Username: ${{ secrets.docker_username }}"
-        username=${{ secrets.docker_username }}
+        echo "Username: ${{ inputs.docker_username }}"
+        username=${{ inputs.docker_username }}
         echo "Password: [REDACTED]"  # Do not echo secrets directly!
         echo "Token length: ${#DOCKER_TOKEN}"  # Check token is being set
         echo "Username length: ${#username}"  # Check token is being set

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -37,17 +37,17 @@ runs:
         DOCKER_TOKEN: ${{ env.DOCKER_TOKEN }}
       run: |
         # Inputs
-        REPO="${{ inputs.repository }}"
+        REPO="${{ inputs.docker_repo }}"
         KEEP_LATEST="${{ inputs.keep_latest }}"
 
-        echo "Cleaning up images for repository: ${{ inputs.docker_repo }}"
+        echo "Cleaning up images for repository: $REPO"
         CURRENT_PAGE=1
 
         while true; do
-          echo "Fetching page $CURRENT_PAGE for tags in ${{ inputs.docker_repo }}..."
+          echo "Fetching page $CURRENT_PAGE for tags in $REPO..."
           
           # Fetch all tags for the repository
-          url="https://hub.docker.com/v2/repositories/${{ inputs.docker_repo }}/tags?page=$CURRENT_PAGE&page_size=100"
+          url="https://hub.docker.com/v2/repositories/$REPO/tags?page=$CURRENT_PAGE&page_size=100"
           echo "Url is: $url"
 
           response=$(curl -s -H "Authorization: JWT $DOCKER_TOKEN" "$url")
@@ -59,10 +59,10 @@ runs:
               break
           fi
            
-          # TAGS=$(curl -s -H "Authorization: JWT $DOCKER_TOKEN" "https://hub.docker.com/v2/repositories/${{ inputs.docker_repo }}/tags?page=$CURRENT_PAGE&page_size=100" | jq -r '.results[] | select(.name | endswith(".dev")) | .name' | sort -r)
+          # TAGS=$(curl -s -H "Authorization: JWT $DOCKER_TOKEN" "https://hub.docker.com/v2/repositories/$REPO/tags?page=$CURRENT_PAGE&page_size=100" | jq -r '.results[] | select(.name | endswith(".dev")) | .name' | sort -r)
 
           if [[ "$next" == "null" ]]; then
-            echo "Exiting paging loop for ${{ inputs.docker_repo }}..."
+            echo "Exiting paging loop for $REPO..."
             break
           fi
 
@@ -75,9 +75,10 @@ runs:
           for TAG in $TAGS_TO_DELETE; do
             echo "Deleting tag: $TAG"
 
-              #curl -s -X DELETE -H "Authorization: JWT $DOCKER_TOKEN" "https://hub.docker.com/v2/repositories/${{ inputs.docker_repo }}/tags/$TAG"
+              # curl -s -X DELETE -H "Authorization: JWT $DOCKER_TOKEN" "https://hub.docker.com/v2/repositories/$REPO/tags/$TAG"
               echo "Deleted tag: $TAG"
           done
+
         done
 
         echo "Cleanup completed for repository: $REPO"

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -28,7 +28,9 @@ runs:
       shell: bash
       run: |
         echo "Authenticating with Docker Hub..."
-        TOKEN=$(curl -s -X POST -u "${{ inputs.docker_username }}:${{ inputs.docker_password }}" "https://hub.docker.com/v2/users/login/" | jq -r '.token')
+        response=$(curl -s -X POST -u "${{ inputs.docker_username }}:${{ inputs.docker_password }}" "https://hub.docker.com/v2/users/login/")
+        echo "Authentication Response: $response"
+        TOKEN=$(response | jq -r '.token')
         echo "DOCKER_TOKEN=$TOKEN" >> $GITHUB_ENV
 
     - name: Cleanup Repository Images

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -79,6 +79,7 @@ runs:
           for TAG in $TAGS_TO_DELETE; do
             deleteUrl=https://hub.docker.com/v2/repositories/$REPO/tags/$TAG
             echo "Deleting tag: $TAG - $deleteUrl"
+            echo "Token length B: ${#DOCKER_TOKEN}"  # Check token is being set
 
             response=$(curl -v -s -X DELETE -H "Authorization: Bearer $DOCKER_TOKEN" -o response.txt -w "%{http_code}" "$deleteUrl")
             http_code="${response: -3}"

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -28,7 +28,7 @@ runs:
       shell: bash
       run: |
         echo "Authenticating with Docker Hub..."
-        response=$(curl -s -X POST -u "${{ inputs.docker_username }}:${{ inputs.docker_password }}" "https://hub.docker.com/v2/users/login/")
+        response=$(curl -s -X POST -H "Content-Type: application/json" -d "{\"username\":\"${{ inputs.docker_username }}\",\"password\":\"${{ inputs.docker_password }}\"}" "https://hub.docker.com/v2/users/login/")
         echo "Authentication Response: $response"
         TOKEN=$(response | jq -r '.token')
         echo "DOCKER_TOKEN=$TOKEN" >> $GITHUB_ENV

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -75,10 +75,11 @@ runs:
           for TAG in $TAGS_TO_DELETE; do
             echo "Deleting tag: $TAG"
 
-              response=$(curl -s -X DELETE -w "%{http_code}" -H "Authorization: JWT $DOCKER_TOKEN" "https://hub.docker.com/v2/repositories/$REPO/tags/$TAG")
+              response=$(curl -s -X DELETE -o response.txt -w "%{http_code}" -H "Authorization: JWT $DOCKER_TOKEN" "https://hub.docker.com/v2/repositories/$REPO/tags/$TAG")
               http_code="${response: -3}"
               if [[ $http_code -ne 204 ]]; then
-                echo "Deleting $TAG Request failed..."
+                response_body=$(<response.txt)
+                echo "Deleting $TAG Request failed ... $response_body"
                 break
               fi
           done

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -68,10 +68,6 @@ runs:
 
           # Get all image tags that end with .dev
           TAGS=$(echo "$response_body" | jq -r '.results[] | select(.name | endswith(".dev")) | .name')
-          if [[ -z "$TAGS" ]]; then
-            echo "No Tags found."
-            exit 1
-          fi
            
           # Get tags to delete (skip the first N tags)
           TAGS_TO_DELETE=$(echo "$TAGS" | tail -n +$((KEEP_LATEST + 1)))

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -1,0 +1,69 @@
+name: Build Docker Image
+author: Petar Kramaric
+description: GitHub action for deleting docker hub images
+inputs:
+  docker_username:
+    description: A username of the docker registry
+    required: true
+  docker_password:
+    description: The password associated to the docker registry user
+    required: true
+  docker_repo:
+    description: The repository where the docker image should be saved. Format is {organization}/{repository}
+    required: true
+  keep_latest:
+    description: Keep the latest number of .dev images (how many should not be deleted)
+    required: true
+    default: 10
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+
+    - name: Authenticate with Docker Hub
+        run: |
+          echo "Authenticating with Docker Hub..."
+          TOKEN=$(curl -s -u "${{ inputs.docker_username }}:${{ inputs.docker_password }}" "https://hub.docker.com/v2/users/login/" | jq -r '.token')
+          echo "DOCKER_TOKEN=$TOKEN" >> $GITHUB_ENV
+
+    - name: Cleanup Repository Images
+        env:
+          DOCKER_TOKEN: ${{ env.DOCKER_TOKEN }}
+        run: |
+          # Inputs
+          REPO="${{ inputs.repository }}"
+          KEEP_LATEST="${{ inputs.keep_latest }}"
+
+          echo "Cleaning up images for repository: ${{ inputs.docker_repo }}"
+          CURRENT_PAGE=1
+
+          while true; do
+            echo "Fetching page $CURRENT_PAGE for tags in ${{ inputs.docker_repo }}..."
+            
+            # Fetch all tags for the repository
+            TAGS=$(curl -s -H "Authorization: JWT $DOCKER_TOKEN" "https://hub.docker.com/v2/repositories/flybits/${{ inputs.docker_repo }}/tags?page=$CURRENT_PAGE&page_size=100" | jq -r '.results[] | select(.name | endswith(".dev")) | .name' | sort -r)
+
+            if [[ "$next" == "null" ]]; then
+              echo "Exiting paging loop for ${{ inputs.docker_repo }}..."
+              break
+            fi
+
+            ((CURRENT_PAGE++))
+
+            # Get tags to delete (skip the first N tags)
+            TAGS_TO_DELETE=$(echo "$TAGS" | tail -n +$((KEEP_LATEST + 1)))
+
+            # Loop through tags to delete
+            for TAG in $TAGS_TO_DELETE; do
+              echo "Deleting tag: $TAG"
+
+                #curl -s -X DELETE -H "Authorization: JWT $DOCKER_TOKEN" "https://hub.docker.com/v2/repositories/flybits/${{ inputs.docker_repo }}/tags/$TAG"
+                echo "Deleted tag: $TAG"
+            done
+          done
+
+          echo "Cleanup completed for repository: $REPO"

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -48,7 +48,10 @@ runs:
           echo "Fetching page $CURRENT_PAGE for tags in ${{ inputs.docker_repo }}..."
           
           # Fetch all tags for the repository
-          response=$(curl -s -H "Authorization: JWT $DOCKER_TOKEN" "https://hub.docker.com/v2/repositories/flybits/${{ inputs.docker_repo }}/tags?page=$CURRENT_PAGE&page_size=100")
+          url="https://hub.docker.com/v2/repositories/flybits/${{ inputs.docker_repo }}/tags?page=$CURRENT_PAGE&page_size=100"
+          echo "Url is: $url"
+
+          response=$(curl -s -H "Authorization: JWT $DOCKER_TOKEN" "$url")
           echo "The response is: $response"
 
           TAGS=$(echo "$response" | jq -r '.results[] | select(.name | endswith(".dev")) | .name' | sort -r)

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -22,7 +22,6 @@ runs:
     - name: Install Dependencies
       shell: bash
       run: |
-        sudo apt-get update
         sudo apt-get install -y jq
 
     - name: Authenticate with Docker Hub
@@ -48,7 +47,7 @@ runs:
           echo "Fetching page $CURRENT_PAGE for tags in ${{ inputs.docker_repo }}..."
           
           # Fetch all tags for the repository
-          url="https://hub.docker.com/v2/repositories/flybits/${{ inputs.docker_repo }}/tags?page=$CURRENT_PAGE&page_size=100"
+          url="https://hub.docker.com/v2/repositories/${{ inputs.docker_repo }}/tags?page=$CURRENT_PAGE&page_size=100"
           echo "Url is: $url"
 
           response=$(curl -s -H "Authorization: JWT $DOCKER_TOKEN" "$url")
@@ -60,7 +59,7 @@ runs:
               break
           fi
            
-          # TAGS=$(curl -s -H "Authorization: JWT $DOCKER_TOKEN" "https://hub.docker.com/v2/repositories/flybits/${{ inputs.docker_repo }}/tags?page=$CURRENT_PAGE&page_size=100" | jq -r '.results[] | select(.name | endswith(".dev")) | .name' | sort -r)
+          # TAGS=$(curl -s -H "Authorization: JWT $DOCKER_TOKEN" "https://hub.docker.com/v2/repositories/${{ inputs.docker_repo }}/tags?page=$CURRENT_PAGE&page_size=100" | jq -r '.results[] | select(.name | endswith(".dev")) | .name' | sort -r)
 
           if [[ "$next" == "null" ]]; then
             echo "Exiting paging loop for ${{ inputs.docker_repo }}..."
@@ -76,7 +75,7 @@ runs:
           for TAG in $TAGS_TO_DELETE; do
             echo "Deleting tag: $TAG"
 
-              #curl -s -X DELETE -H "Authorization: JWT $DOCKER_TOKEN" "https://hub.docker.com/v2/repositories/flybits/${{ inputs.docker_repo }}/tags/$TAG"
+              #curl -s -X DELETE -H "Authorization: JWT $DOCKER_TOKEN" "https://hub.docker.com/v2/repositories/${{ inputs.docker_repo }}/tags/$TAG"
               echo "Deleted tag: $TAG"
           done
         done

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -73,7 +73,7 @@ runs:
           for TAG in $TAGS_TO_DELETE; do
             echo "Deleting tag: $TAG - https://hub.docker.com/v2/repositories/$REPO/tags/$TAG"
 
-            response=$(curl -s -X DELETE -o response.txt -w "%{http_code}" -H "Authorization: Bearer $DOCKER_TOKEN" "https://hub.docker.com/v2/repositories/$REPO/tags/$TAG")
+            response=$(curl -X DELETE -H "Authorization: JWT $DOCKER_TOKEN" -o response.txt -w "%{http_code}" "https://hub.docker.com/v2/repositories/$REPO/tags/$TAG")
             http_code="${response: -3}"
             if [[ $http_code -ne 204 ]]; then
               response_body=$(<response.txt)

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -118,6 +118,7 @@ runs:
           fi
 
           #Update pages and set KEEP_LATEST to 0 as for pages > 1 we do not want to keep any values
+          # this is not an issue because it is unlikely that we will have 100 items (the first page) with no .dev images
           KEEP_LATEST=0
           ((CURRENT_PAGE++))
         done

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -37,7 +37,7 @@ runs:
         PAYLOAD=$(echo "$DOCKER_TOKEN" | cut -d '.' -f2 | base64 -d 2>/dev/null)
 
         # Print the payload
-        echo "$PAYLOAD"
+        echo "Payload is: $PAYLOAD"
 
     - name: Cleanup Repository Images
       shell: bash
@@ -80,7 +80,7 @@ runs:
             deleteUrl=https://hub.docker.com/v2/repositories/$REPO/tags/$TAG
             echo "Deleting tag: $TAG - $deleteUrl"
 
-            response=$(curl -s -X DELETE -H "Authorization: JWT $DOCKER_TOKEN" -o response.txt -w "%{http_code}" "$deleteUrl")
+            response=$(curl -s -X DELETE -H "Authorization: Bearer $DOCKER_TOKEN" -o response.txt -w "%{http_code}" "$deleteUrl")
             http_code="${response: -3}"
             if [[ $http_code -ne 204 ]]; then
               response_body=$(<response.txt)

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -79,8 +79,7 @@ runs:
           for TAG in $TAGS_TO_DELETE; do
             deleteUrl=https://hub.docker.com/v2/repositories/$REPO/tags/$TAG
             echo "Deleting tag: $TAG - $deleteUrl"
-            echo "Token length B: ${#DOCKER_TOKEN}"  # Check token is being set
-
+            
             response=$(curl -v -s -X DELETE -H "Authorization: Bearer $DOCKER_TOKEN" -o response.txt -w "%{http_code}" "$deleteUrl")
             http_code="${response: -3}"
             if [[ $http_code -ne 204 ]]; then

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -80,7 +80,7 @@ runs:
             deleteUrl=https://hub.docker.com/v2/repositories/$REPO/tags/$TAG
             echo "Deleting tag: $TAG - $deleteUrl"
 
-            response=$(curl -s -X DELETE -H "Authorization: Bearer $DOCKER_TOKEN" -o response.txt -w "%{http_code}" "$deleteUrl")
+            response=$(curl -v -s -X DELETE -H "Authorization: Bearer $DOCKER_TOKEN" -o response.txt -w "%{http_code}" "$deleteUrl")
             http_code="${response: -3}"
             if [[ $http_code -ne 204 ]]; then
               response_body=$(<response.txt)

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -72,10 +72,19 @@ runs:
           fi
 
           # Get all image tags that end with .dev
-          TAGS=$(echo "$response_body" | jq -r '.results[] | select(.name | endswith(".dev")) | .name')
-           
-          # Get tags to delete (skip the first N tags)
-          TAGS_TO_DELETE=$(echo "$TAGS" | tail -n +$((KEEP_LATEST + 1)))
+          TAGS_DEV=$(echo "$response_body" | jq -r '.results[] | select(.name | endswith(".dev")) | .name')
+
+          # Get all image tags that match the staging regex
+          TAGS_STAGING=$(echo "$response_body" | jq -r '.results[] | select(.name | test("-ecdf6e4$")) | .name')
+
+          # Get tags to delete from TAGS_DEV (skip the first N tags)
+          TAGS_DEV_TO_DELETE=$(echo "$TAGS_DEV" | tail -n +$((KEEP_LATEST + 1)))
+
+          # Get tags to delete from TAGS_STAGING (skip the first N tags)
+          TAGS_STAGING_TO_DELETE=$(echo "$TAGS_STAGING" | tail -n +$((KEEP_LATEST + 1)))
+
+          # Combine the tags to delete from both lists
+          TAGS_TO_DELETE=$(echo -e "$TAGS_DEV_TO_DELETE\n$TAGS_STAGING_TO_DELETE")
 
           # Loop through tags to delete
           for TAG in $TAGS_TO_DELETE; do

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -1,4 +1,4 @@
-name: Build Docker Image
+name: Cleanup Docker Images
 author: Petar Kramaric
 description: GitHub action for deleting docker hub images
 inputs:

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -30,7 +30,7 @@ runs:
         echo "Authenticating with Docker Hub..."
         response=$(curl -s -X POST -H "Content-Type: application/json" -d "{\"username\":\"${{ inputs.docker_username }}\",\"password\":\"${{ inputs.docker_password }}\"}" "https://hub.docker.com/v2/users/login/")
         echo "Authentication Response: $response"
-        TOKEN=$(response | jq -r '.token')
+        TOKEN=$("$response" | jq -r '.token')
         echo "DOCKER_TOKEN=$TOKEN" >> $GITHUB_ENV
 
     - name: Cleanup Repository Images

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -96,6 +96,7 @@ runs:
             break
           fi
 
+          KEEP_LATEST=0
           ((CURRENT_PAGE++))
         done
 

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -57,16 +57,16 @@ runs:
           response_body=$(<response.txt)
           if [[ $http_code -ne 200 ]]; then
             echo "Request failed..."
-            break
+            exit 1
           fi
 
           TAGS=$(echo "$response_body" | jq -r '.results[] | select(.name | endswith(".dev")) | .name' | sort -r)
           if [[ -z "$TAGS" ]]; then
               echo "No Tags found."
-              break
+              exit 1
           fi
            
-          # TAGS=$(curl -s -H "Authorization: JWT $DOCKER_TOKEN" "https://hub.docker.com/v2/repositories/$REPO/tags?page=$CURRENT_PAGE&page_size=100" | jq -r '.results[] | select(.name | endswith(".dev")) | .name' | sort -r)
+          # TAGS=$(curl -s -H "Authorization: Bearer $DOCKER_TOKEN" "https://hub.docker.com/v2/repositories/$REPO/tags?page=$CURRENT_PAGE&page_size=100" | jq -r '.results[] | select(.name | endswith(".dev")) | .name' | sort -r)
 
           # Get tags to delete (skip the first N tags)
           TAGS_TO_DELETE=$(echo "$TAGS" | tail -n +$((KEEP_LATEST + 1)))
@@ -75,13 +75,13 @@ runs:
           for TAG in $TAGS_TO_DELETE; do
             echo "Deleting tag: $TAG"
 
-              response=$(curl -s -X DELETE -o response.txt -w "%{http_code}" -H "Authorization: JWT $DOCKER_TOKEN" "https://hub.docker.com/v2/repositories/$REPO/tags/$TAG")
-              http_code="${response: -3}"
-              if [[ $http_code -ne 204 ]]; then
-                response_body=$(<response.txt)
-                echo "Deleting $TAG Request failed ... $response_body"
-                break
-              fi
+            response=$(curl -s -X DELETE -o response.txt -w "%{http_code}" -H "Authorization: Bearer $DOCKER_TOKEN" "https://hub.docker.com/v2/repositories/$REPO/tags/$TAG")
+            http_code="${response: -3}"
+            if [[ $http_code -ne 204 ]]; then
+              response_body=$(<response.txt)
+              echo "Deleting $TAG Request failed $http_code ... $response_body"
+              exit 1
+            fi
           done
 
           if [[ "$next" == "null" ]]; then

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -52,23 +52,24 @@ runs:
           url="https://hub.docker.com/v2/repositories/$REPO/tags?page=$CURRENT_PAGE&page_size=100"
           echo "Url is: $url"
 
-          response=$(curl -s -H "Authorization: JWT $DOCKER_TOKEN" "$url")
-          echo "The response is: $response"
+          response=$(curl -s -H "Authorization: JWT $DOCKER_TOKEN" -o response.txt -w "%{http_code}" "$url")
+          # Split the status code and response
+          http_code="${response: -3}"
+          echo "The response Code is: $http_code"
+          response_body=$(<response.txt)
+          echo "The response is: $response_body"
+          if [[ $http_code -ne 200 ]]; then
+            echo "Request failed..."
+            break
+          fi
 
-          TAGS=$(echo "$response" | jq -r '.results[] | select(.name | endswith(".dev")) | .name' | sort -r)
+          TAGS=$(echo "$response_body" | jq -r '.results[] | select(.name | endswith(".dev")) | .name' | sort -r)
           if [[ -z "$TAGS" ]]; then
               echo "No Tags found."
               break
           fi
            
           # TAGS=$(curl -s -H "Authorization: JWT $DOCKER_TOKEN" "https://hub.docker.com/v2/repositories/$REPO/tags?page=$CURRENT_PAGE&page_size=100" | jq -r '.results[] | select(.name | endswith(".dev")) | .name' | sort -r)
-
-          if [[ "$next" == "null" ]]; then
-            echo "Exiting paging loop for $REPO..."
-            break
-          fi
-
-          ((CURRENT_PAGE++))
 
           # Get tags to delete (skip the first N tags)
           TAGS_TO_DELETE=$(echo "$TAGS" | tail -n +$((KEEP_LATEST + 1)))
@@ -81,6 +82,12 @@ runs:
               echo "Deleted tag: $TAG"
           done
 
+          if [[ "$next" == "null" ]]; then
+            echo "Exiting paging loop for $REPO..."
+            break
+          fi
+
+          ((CURRENT_PAGE++))
         done
 
         echo "Cleanup completed for repository: $REPO"

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -75,7 +75,7 @@ runs:
           TAGS_DEV=$(echo "$response_body" | jq -r '.results[] | select(.name | endswith(".dev")) | .name')
 
           # Get all image tags that match the staging regex
-          TAGS_STAGING=$(echo "$response_body" | jq -r '.results[] | select(.name | test("-[a-zA-Z0-9]{7}$")) | .name')
+          TAGS_STAGING=$(echo "$response_body" | jq -r '.results[] | select(.name | test("-[a-zA-Z0-9]{7}$|[a-zA-Z0-9]{7}(?!(.dev))")) | .name')
          
           # Get tags to delete from TAGS_DEV (skip the first N tags)
           TAGS_DEV_TO_DELETE=$(echo "$TAGS_DEV" | tail -n +$((KEEP_LATEST + 1)))

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -75,9 +75,8 @@ runs:
           TAGS_DEV=$(echo "$response_body" | jq -r '.results[] | select(.name | endswith(".dev")) | .name')
 
           # Get all image tags that match the staging regex
-          TAGS_STAGING=$(echo "$response_body" | jq -r '.results[] | select(.name | test("-ecdf6e4$")) | .name')
-          echo "TAGS STAGING TO DELETE: $TAGS_STAGING"
-
+          TAGS_STAGING=$(echo "$response_body" | jq -r '.results[] | select(.name | test("-[a-zA-Z0-9]{7}")) | .name')
+         
           # Get tags to delete from TAGS_DEV (skip the first N tags)
           TAGS_DEV_TO_DELETE=$(echo "$TAGS_DEV" | tail -n +$((KEEP_LATEST + 1)))
 

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -30,14 +30,13 @@ runs:
         username: ${{ inputs.docker_username }}
         password: ${{ inputs.docker_password }}
 
-    - name: Authenticate with Docker Hub
+    - name: Retrieving Docker JWT
       shell: bash
       run: |
         echo "Authenticating with Docker Hub..."
         # Decode the Docker config to extract the token
         TOKEN=$(jq -r '.auths["https://index.docker.io/v1/"].auth' ~/.docker/config.json | base64 -d | cut -d':' -f2)
         echo "DOCKER_TOKEN=${TOKEN}" >> $GITHUB_ENV
-        
 
     - name: Cleanup Repository Images
       shell: bash
@@ -58,14 +57,16 @@ runs:
           echo "Fetching page $CURRENT_PAGE for tags in $REPO - $url"
 
           response=$(curl -s -H "Authorization: JWT $DOCKER_TOKEN" -o response.txt -w "%{http_code}" "$url")
-          # Split the status code and response
+          
+          # Split the status code and response if status code is not 200 exit ungracefully
           http_code="${response: -3}"
           response_body=$(<response.txt)
           if [[ $http_code -ne 200 ]]; then
-            echo "Request failed..."
+            echo "Request failed - $response_body ..."
             exit 1
           fi
 
+          # Get all image tags that end with .dev
           TAGS=$(echo "$response_body" | jq -r '.results[] | select(.name | endswith(".dev")) | .name')
           if [[ -z "$TAGS" ]]; then
             echo "No Tags found."

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -46,18 +46,15 @@ runs:
         CURRENT_PAGE=1
 
         while true; do
-          echo "Fetching page $CURRENT_PAGE for tags in $REPO..."
           
           # Fetch all tags for the repository
           url="https://hub.docker.com/v2/repositories/$REPO/tags?page=$CURRENT_PAGE&page_size=100"
-          echo "Url is: $url"
+         echo "Fetching page $CURRENT_PAGE for tags in $REPO - $url"
 
           response=$(curl -s -H "Authorization: JWT $DOCKER_TOKEN" -o response.txt -w "%{http_code}" "$url")
           # Split the status code and response
           http_code="${response: -3}"
-          echo "The response Code is: $http_code"
           response_body=$(<response.txt)
-          echo "The response is: $response_body"
           if [[ $http_code -ne 200 ]]; then
             echo "Request failed..."
             break
@@ -78,8 +75,12 @@ runs:
           for TAG in $TAGS_TO_DELETE; do
             echo "Deleting tag: $TAG"
 
-              # curl -s -X DELETE -H "Authorization: JWT $DOCKER_TOKEN" "https://hub.docker.com/v2/repositories/$REPO/tags/$TAG"
-              echo "Deleted tag: $TAG"
+              response=$(curl -s -X DELETE -w "%{http_code}" -H "Authorization: JWT $DOCKER_TOKEN" "https://hub.docker.com/v2/repositories/$REPO/tags/$TAG")
+              http_code="${response: -3}"
+              if [[ $http_code -ne 204 ]]; then
+                echo "Deleting $TAG Request failed..."
+                break
+              fi
           done
 
           if [[ "$next" == "null" ]]; then

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -61,6 +61,11 @@ runs:
           # Split the status code and response if status code is not 200 exit ungracefully
           http_code="${response: -3}"
           response_body=$(<response.txt)
+          if [[ $http_code -eq 404 ]]; then
+            echo "Could not find object so most likely we have reached the end - $response_body ..."
+            break
+          fi
+
           if [[ $http_code -ne 200 ]]; then
             echo "Request failed - $response_body ..."
             exit 1

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -66,14 +66,12 @@ runs:
               exit 1
           fi
            
-          # TAGS=$(curl -s -H "Authorization: Bearer $DOCKER_TOKEN" "https://hub.docker.com/v2/repositories/$REPO/tags?page=$CURRENT_PAGE&page_size=100" | jq -r '.results[] | select(.name | endswith(".dev")) | .name' | sort -r)
-
           # Get tags to delete (skip the first N tags)
           TAGS_TO_DELETE=$(echo "$TAGS" | tail -n +$((KEEP_LATEST + 1)))
 
           # Loop through tags to delete
           for TAG in $TAGS_TO_DELETE; do
-            echo "Deleting tag: $TAG"
+            echo "Deleting tag: $TAG - https://hub.docker.com/v2/repositories/$REPO/tags/$TAG"
 
             response=$(curl -s -X DELETE -o response.txt -w "%{http_code}" -H "Authorization: Bearer $DOCKER_TOKEN" "https://hub.docker.com/v2/repositories/$REPO/tags/$TAG")
             http_code="${response: -3}"

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -20,50 +20,50 @@ runs:
   using: "composite"
   steps:
     - name: Install Dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y jq
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y jq
 
     - name: Authenticate with Docker Hub
-        run: |
-          echo "Authenticating with Docker Hub..."
-          TOKEN=$(curl -s -u "${{ inputs.docker_username }}:${{ inputs.docker_password }}" "https://hub.docker.com/v2/users/login/" | jq -r '.token')
-          echo "DOCKER_TOKEN=$TOKEN" >> $GITHUB_ENV
+      run: |
+        echo "Authenticating with Docker Hub..."
+        TOKEN=$(curl -s -u "${{ inputs.docker_username }}:${{ inputs.docker_password }}" "https://hub.docker.com/v2/users/login/" | jq -r '.token')
+        echo "DOCKER_TOKEN=$TOKEN" >> $GITHUB_ENV
 
     - name: Cleanup Repository Images
-        env:
-          DOCKER_TOKEN: ${{ env.DOCKER_TOKEN }}
-        run: |
-          # Inputs
-          REPO="${{ inputs.repository }}"
-          KEEP_LATEST="${{ inputs.keep_latest }}"
+      env:
+        DOCKER_TOKEN: ${{ env.DOCKER_TOKEN }}
+      run: |
+        # Inputs
+        REPO="${{ inputs.repository }}"
+        KEEP_LATEST="${{ inputs.keep_latest }}"
 
-          echo "Cleaning up images for repository: ${{ inputs.docker_repo }}"
-          CURRENT_PAGE=1
+        echo "Cleaning up images for repository: ${{ inputs.docker_repo }}"
+        CURRENT_PAGE=1
 
-          while true; do
-            echo "Fetching page $CURRENT_PAGE for tags in ${{ inputs.docker_repo }}..."
-            
-            # Fetch all tags for the repository
-            TAGS=$(curl -s -H "Authorization: JWT $DOCKER_TOKEN" "https://hub.docker.com/v2/repositories/flybits/${{ inputs.docker_repo }}/tags?page=$CURRENT_PAGE&page_size=100" | jq -r '.results[] | select(.name | endswith(".dev")) | .name' | sort -r)
+        while true; do
+          echo "Fetching page $CURRENT_PAGE for tags in ${{ inputs.docker_repo }}..."
+          
+          # Fetch all tags for the repository
+          TAGS=$(curl -s -H "Authorization: JWT $DOCKER_TOKEN" "https://hub.docker.com/v2/repositories/flybits/${{ inputs.docker_repo }}/tags?page=$CURRENT_PAGE&page_size=100" | jq -r '.results[] | select(.name | endswith(".dev")) | .name' | sort -r)
 
-            if [[ "$next" == "null" ]]; then
-              echo "Exiting paging loop for ${{ inputs.docker_repo }}..."
-              break
-            fi
+          if [[ "$next" == "null" ]]; then
+            echo "Exiting paging loop for ${{ inputs.docker_repo }}..."
+            break
+          fi
 
-            ((CURRENT_PAGE++))
+          ((CURRENT_PAGE++))
 
-            # Get tags to delete (skip the first N tags)
-            TAGS_TO_DELETE=$(echo "$TAGS" | tail -n +$((KEEP_LATEST + 1)))
+          # Get tags to delete (skip the first N tags)
+          TAGS_TO_DELETE=$(echo "$TAGS" | tail -n +$((KEEP_LATEST + 1)))
 
-            # Loop through tags to delete
-            for TAG in $TAGS_TO_DELETE; do
-              echo "Deleting tag: $TAG"
+          # Loop through tags to delete
+          for TAG in $TAGS_TO_DELETE; do
+            echo "Deleting tag: $TAG"
 
-                #curl -s -X DELETE -H "Authorization: JWT $DOCKER_TOKEN" "https://hub.docker.com/v2/repositories/flybits/${{ inputs.docker_repo }}/tags/$TAG"
-                echo "Deleted tag: $TAG"
-            done
+              #curl -s -X DELETE -H "Authorization: JWT $DOCKER_TOKEN" "https://hub.docker.com/v2/repositories/flybits/${{ inputs.docker_repo }}/tags/$TAG"
+              echo "Deleted tag: $TAG"
           done
+        done
 
-          echo "Cleanup completed for repository: $REPO"
+        echo "Cleanup completed for repository: $REPO"

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -48,7 +48,16 @@ runs:
           echo "Fetching page $CURRENT_PAGE for tags in ${{ inputs.docker_repo }}..."
           
           # Fetch all tags for the repository
-          TAGS=$(curl -s -H "Authorization: JWT $DOCKER_TOKEN" "https://hub.docker.com/v2/repositories/flybits/${{ inputs.docker_repo }}/tags?page=$CURRENT_PAGE&page_size=100" | jq -r '.results[] | select(.name | endswith(".dev")) | .name' | sort -r)
+          response=$(curl -s -H "Authorization: JWT $DOCKER_TOKEN" "https://hub.docker.com/v2/repositories/flybits/${{ inputs.docker_repo }}/tags?page=$CURRENT_PAGE&page_size=100")
+          echo "The response is: $response"
+
+          TAGS=$(echo "$response" | jq -r '.results[] | select(.name | endswith(".dev")) | .name' | sort -r)
+          if [[ -z "$TAGS" ]]; then
+              echo "No Tags found."
+              break
+          fi
+           
+          # TAGS=$(curl -s -H "Authorization: JWT $DOCKER_TOKEN" "https://hub.docker.com/v2/repositories/flybits/${{ inputs.docker_repo }}/tags?page=$CURRENT_PAGE&page_size=100" | jq -r '.results[] | select(.name | endswith(".dev")) | .name' | sort -r)
 
           if [[ "$next" == "null" ]]; then
             echo "Exiting paging loop for ${{ inputs.docker_repo }}..."

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -33,6 +33,12 @@ runs:
         TOKEN=$(echo "$response" | jq -r '.token')
         echo "DOCKER_TOKEN=$TOKEN" >> $GITHUB_ENV
 
+        # Extract and decode the payload
+        PAYLOAD=$(echo "$DOCKER_TOKEN" | cut -d '.' -f2 | base64 -d 2>/dev/null)
+
+        # Print the payload
+        echo "$PAYLOAD"
+
     - name: Cleanup Repository Images
       shell: bash
       env:


### PR DESCRIPTION
<!--
  If this pull request addresses an issue, make sure your description includes "Resolves #xx", "Fixes #xx", or "Closes #xx".
  https://help.github.com/articles/closing-issues-using-keywords
-->

## Description
We want to be able to delete docker images from Docker Hub due to raising cost of hosting infinite number of images on their registry. This job will get all the tags in a Docker Hub repo and only keep the latest X number of tags based on the KEEP_LATEST input. This will only apply to .dev and staging builds. So if you enter 10 in keep latest in your repository action then only the latest 10 .dev images and 10 staging images will be kept. Below is an example of the this action being used in the Labels repo.

![Screenshot 2025-01-14 at 11 50 46](https://github.com/user-attachments/assets/a0d48d85-51f1-4444-8518-2f7dbd7c0ed5)

### Checklist

  - [ ] PR title is clear and describes the work
  - [ ] Commit messages are self-explanatory and summarize the change

### Action

  - [ ] Tests are provided/updated for the new/existing action
  - [ ] The action maintainer in `CODEOWNERS` is updated
  - [ ] The `README.md` file for new/existing action is created/updated
