### PR TITLE
[PET-000] Add nightly job actions

### DIFF
--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -24,7 +24,7 @@ runs:
       run: |
         sudo apt-get install -y jq
 
-    - name: Inputs validation
+    - name: Input Validation
       shell: bash
       run: |
         [[ "${{ inputs.keep_latest }}"  -ge 1 ]] || { echo "keep_latest must be at least 1" ; exit 1; }

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -24,7 +24,7 @@ runs:
       run: |
         sudo apt-get install -y jq
 
-     - name: Inputs validation
+    - name: Inputs validation
       shell: bash
       run: |
         [[ "${{ inputs.keep_latest }}"  -ge 1 ]] || { echo "keep_latest must be at least 1" ; exit 1; }

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -27,7 +27,7 @@ runs:
     - name: Input Validation
       shell: bash
       run: |
-        [[ "${{ inputs.keep_latest }}"  -ge 1 ]] || { echo "keep_latest must be at least 1" ; exit 1; }
+        [[ "${{ inputs.keep_latest }}" -ge 1 ]] || { echo "keep_latest must be at least 1" ; exit 1; }
 
     - name: Log in to Docker Hub
       uses: docker/login-action@v3

--- a/backend/nightly/action.yaml
+++ b/backend/nightly/action.yaml
@@ -31,6 +31,10 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{inputs.branch}}
+
     #Clean up docker images
     - uses: ./backend/clean-docker
       id: docker_cleanup_success

--- a/backend/nightly/action.yaml
+++ b/backend/nightly/action.yaml
@@ -33,7 +33,7 @@ runs:
   steps:
 
     #Clean up docker images
-    - uses: ./../clean-docker@main
+    - uses: ./../clean-docker@ccd0f2e5baa732fcf0f94d8fa859e7acb85b222f
       id: docker_cleanup
       with:
         docker_username: ${{ inputs.docker_username }}
@@ -48,7 +48,7 @@ runs:
       shell: bash
       run: echo "SUCCESS=${{ steps.docker_cleanup.outcome == 'success' }}" >> $GITHUB_ENV
     
-    - uses: ./../go-vulncheck@6main
+    - uses: ./../go-vulncheck@ccd0f2e5baa732fcf0f94d8fa859e7acb85b222f
       if: always()  # Ensure this step runs even if the previous one failed
       with:
         slack_webhook_url: ${{ inputs.slack_webhook_url }}

--- a/backend/nightly/action.yaml
+++ b/backend/nightly/action.yaml
@@ -46,7 +46,7 @@ runs:
     - name: Capture step status
       if: always()  # Ensure this step runs even if the previous one failed
       shell: bash
-      run: echo "SUCCESS=${{ steps.docker_cleanup.outcome == 'success' }}" >> $GITHUB_ENV
+      run: echo "DOCKER_CLEANUP_SUCCESS=${{ steps.docker_cleanup.outcome == 'success' }}" >> $GITHUB_ENV
     
     - uses: flybits/actions/backend/go-vulncheck@main
       if: always()  # Ensure this step runs even if the previous one failed

--- a/backend/nightly/action.yaml
+++ b/backend/nightly/action.yaml
@@ -33,7 +33,7 @@ runs:
   steps:
 
     #Clean up docker images
-    - uses: ./../clean-docker@ccd0f2e5baa732fcf0f94d8fa859e7acb85b222f
+    - uses: flybits/actions/backend/clean-docker@ccd0f2e5baa732fcf0f94d8fa859e7acb85b222f
       id: docker_cleanup
       with:
         docker_username: ${{ inputs.docker_username }}
@@ -48,7 +48,7 @@ runs:
       shell: bash
       run: echo "SUCCESS=${{ steps.docker_cleanup.outcome == 'success' }}" >> $GITHUB_ENV
     
-    - uses: ./../go-vulncheck@ccd0f2e5baa732fcf0f94d8fa859e7acb85b222f
+    - uses: flybits/actions/backend/go-vulncheck@ccd0f2e5baa732fcf0f94d8fa859e7acb85b222f
       if: always()  # Ensure this step runs even if the previous one failed
       with:
         slack_webhook_url: ${{ inputs.slack_webhook_url }}

--- a/backend/nightly/action.yaml
+++ b/backend/nightly/action.yaml
@@ -33,7 +33,7 @@ runs:
   steps:
 
     #Clean up docker images
-    - uses: flybits/actions/backend/clean-docker@6e65b83c81904f40d7525528c5a44647dc9d241f
+    - uses: flybits/actions/backend/clean-docker@main
       id: docker_cleanup
       with:
         docker_username: ${{ inputs.docker_username }}
@@ -48,7 +48,7 @@ runs:
       shell: bash
       run: echo "SUCCESS=${{ steps.docker_cleanup.outcome == 'success' }}" >> $GITHUB_ENV
     
-    - uses: flybits/actions/backend/go-vulncheck@6e65b83c81904f40d7525528c5a44647dc9d241f
+    - uses: flybits/actions/backend/go-vulncheck@6main
       if: always()  # Ensure this step runs even if the previous one failed
       with:
         slack_webhook_url: ${{ inputs.slack_webhook_url }}

--- a/backend/nightly/action.yaml
+++ b/backend/nightly/action.yaml
@@ -44,6 +44,7 @@ runs:
     # Capture the outcome of the docker image step
     - name: Capture step status
       if: always()  # Ensure this step runs even if the previous one failed
+      shell: bash
       run: echo "SUCCESS=${{ steps.docker_cleanup_success.outcome == 'success' }}" >> $GITHUB_ENV
     
     - uses: ./backend/go-vulncheck
@@ -56,6 +57,7 @@ runs:
     # Fail the job if the docker image failed
     - name: Fail job if Docker Image Cleanup failed
       if: env.SUCCESS == 'false'
+      shell: bash
       run: |
         echo "Docker Cleanup failed, marking job as failed."
         exit 1

--- a/backend/nightly/action.yaml
+++ b/backend/nightly/action.yaml
@@ -1,0 +1,61 @@
+name: Nightly Jobs
+author: Petar Kramaric
+description: GitHub action for running nightly jobs
+inputs:
+  slack_webhook_url:
+    description: A Slack webhook url for alerting on failures
+    required: false
+  deployment_token:
+    description: A deployment token for github
+    required: true
+  branch:
+    description: The branch to run this job will run on
+    required: true
+  show_success_slack_msg:
+    description: indicates that all failures and successes should be displayed in slack, otherwise only failures will appear
+    required: true
+  docker_username:
+    description: A username of the docker registry
+    required: true
+  docker_password:
+    description: The password associated to the docker registry user
+    required: true
+  docker_repo:
+    description: The repository where the docker image should be saved. Format is {organization}/{repository}
+    required: true
+  keep_latest:
+    description: Keep the latest number of .dev images (how many should not be deleted)
+    required: true
+    default: 10
+
+runs:
+  using: "composite"
+  steps:
+    #Clean up docker images
+    - uses: ./backend/clean-docker
+      id: docker_cleanup_success
+      with:
+        docker_username: ${{ inputs.docker_username }}
+        docker_password : ${{ inputs.docker_password }}
+        docker_repo: ${{ inputs.docker_repo }}
+        keep_latest: ${{ inputs.keep_latest }}
+      continue-on-error: true
+
+    # Capture the outcome of the docker image step
+    - name: Capture step status
+      if: always()  # Ensure this step runs even if the previous one failed
+      run: echo "SUCCESS=${{ steps.docker_cleanup_success.outcome == 'success' }}" >> $GITHUB_ENV
+    
+    - uses: ./backend/go-vulncheck
+      if: always()  # Ensure this step runs even if the previous one failed
+      with:
+        slack_webhook_url: ${{ inputs.slack_webhook_url }}
+        deployment_token : ${{ inputs.deployment_token }}
+        branch: ${{ inputs.branch }}
+
+    # Fail the job if the docker image failed
+    - name: Fail job if Docker Image Cleanup failed
+      if: env.SUCCESS == 'false'
+      run: |
+        echo "Docker Cleanup failed, marking job as failed."
+        exit 1

--- a/backend/nightly/action.yaml
+++ b/backend/nightly/action.yaml
@@ -33,7 +33,7 @@ runs:
   steps:
 
     #Clean up docker images
-    - uses: flybits/actions/backend/clean-docker@ccd0f2e5baa732fcf0f94d8fa859e7acb85b222f
+    - uses: flybits/actions/backend/clean-docker@main
       id: docker_cleanup
       with:
         docker_username: ${{ inputs.docker_username }}
@@ -48,7 +48,7 @@ runs:
       shell: bash
       run: echo "SUCCESS=${{ steps.docker_cleanup.outcome == 'success' }}" >> $GITHUB_ENV
     
-    - uses: flybits/actions/backend/go-vulncheck@ccd0f2e5baa732fcf0f94d8fa859e7acb85b222f
+    - uses: flybits/actions/backend/go-vulncheck@main
       if: always()  # Ensure this step runs even if the previous one failed
       with:
         slack_webhook_url: ${{ inputs.slack_webhook_url }}

--- a/backend/nightly/action.yaml
+++ b/backend/nightly/action.yaml
@@ -36,7 +36,7 @@ runs:
         ref: ${{inputs.branch}}
 
     #Clean up docker images
-    - uses: ./backend/clean-docker
+    - uses: flybits/actions/backend/clean-docker@main
       id: docker_cleanup_success
       with:
         docker_username: ${{ inputs.docker_username }}
@@ -51,7 +51,7 @@ runs:
       shell: bash
       run: echo "SUCCESS=${{ steps.docker_cleanup_success.outcome == 'success' }}" >> $GITHUB_ENV
     
-    - uses: ./backend/go-vulncheck
+    - uses: flybits/actions/backend/go-vulncheck@main
       if: always()  # Ensure this step runs even if the previous one failed
       with:
         slack_webhook_url: ${{ inputs.slack_webhook_url }}

--- a/backend/nightly/action.yaml
+++ b/backend/nightly/action.yaml
@@ -31,13 +31,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
-      with:
-        ref: ${{inputs.branch}}
 
     #Clean up docker images
     - uses: flybits/actions/backend/clean-docker@6e65b83c81904f40d7525528c5a44647dc9d241f
-      id: docker_cleanup_success
+      id: docker_cleanup
       with:
         docker_username: ${{ inputs.docker_username }}
         docker_password : ${{ inputs.docker_password }}
@@ -49,7 +46,7 @@ runs:
     - name: Capture step status
       if: always()  # Ensure this step runs even if the previous one failed
       shell: bash
-      run: echo "SUCCESS=${{ steps.docker_cleanup_success.outcome == 'success' }}" >> $GITHUB_ENV
+      run: echo "SUCCESS=${{ steps.docker_cleanup.outcome == 'success' }}" >> $GITHUB_ENV
     
     - uses: flybits/actions/backend/go-vulncheck@6e65b83c81904f40d7525528c5a44647dc9d241f
       if: always()  # Ensure this step runs even if the previous one failed

--- a/backend/nightly/action.yaml
+++ b/backend/nightly/action.yaml
@@ -57,7 +57,7 @@ runs:
 
     # Fail the job if the docker image failed
     - name: Fail job if Docker Image Cleanup failed
-      if: env.SUCCESS == 'false'
+      if: env.DOCKER_CLEANUP_SUCCESS == 'false'
       shell: bash
       run: |
         echo "Docker Cleanup failed, marking job as failed."

--- a/backend/nightly/action.yaml
+++ b/backend/nightly/action.yaml
@@ -33,7 +33,7 @@ runs:
   steps:
 
     #Clean up docker images
-    - uses: flybits/actions/backend/clean-docker@main
+    - uses: ./../clean-docker@main
       id: docker_cleanup
       with:
         docker_username: ${{ inputs.docker_username }}
@@ -48,7 +48,7 @@ runs:
       shell: bash
       run: echo "SUCCESS=${{ steps.docker_cleanup.outcome == 'success' }}" >> $GITHUB_ENV
     
-    - uses: flybits/actions/backend/go-vulncheck@6main
+    - uses: ./../go-vulncheck@6main
       if: always()  # Ensure this step runs even if the previous one failed
       with:
         slack_webhook_url: ${{ inputs.slack_webhook_url }}

--- a/backend/nightly/action.yaml
+++ b/backend/nightly/action.yaml
@@ -36,7 +36,7 @@ runs:
         ref: ${{inputs.branch}}
 
     #Clean up docker images
-    - uses: flybits/actions/backend/clean-docker@main
+    - uses: flybits/actions/backend/clean-docker@6e65b83c81904f40d7525528c5a44647dc9d241f
       id: docker_cleanup_success
       with:
         docker_username: ${{ inputs.docker_username }}
@@ -51,7 +51,7 @@ runs:
       shell: bash
       run: echo "SUCCESS=${{ steps.docker_cleanup_success.outcome == 'success' }}" >> $GITHUB_ENV
     
-    - uses: flybits/actions/backend/go-vulncheck@main
+    - uses: flybits/actions/backend/go-vulncheck@6e65b83c81904f40d7525528c5a44647dc9d241f
       if: always()  # Ensure this step runs even if the previous one failed
       with:
         slack_webhook_url: ${{ inputs.slack_webhook_url }}


### PR DESCRIPTION
<!--
  If this pull request addresses an issue, make sure your description includes "Resolves #xx", "Fixes #xx", or "Closes #xx".
  https://help.github.com/articles/closing-issues-using-keywords
-->

## Description
Added a nightly task to backned actions that combines other tasks, in this case, clean-docker and govulncheck. By having one nightly job implementing on each repository should be fairly straightforward. Below is an example of using this nightly task job.

![Screenshot 2025-01-30 at 13 37 48](https://github.com/user-attachments/assets/ff100b17-b2c1-47b4-acf3-a5e8714004c2)

### Checklist

  - [ ] PR title is clear and describes the work
  - [ ] Commit messages are self-explanatory and summarize the change

### Action

  - [ ] Tests are provided/updated for the new/existing action
  - [ ] The action maintainer in `CODEOWNERS` is updated
  - [ ] The `README.md` file for new/existing action is created/updated
