### PR TITLE
[PET-000] Allow for a list of images to be passed for Docker Cleanup Job

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # Ref: https://help.github.com/articles/about-code-owners
 
 # Default owners for everything in the repo (primary and secondary champions)
-* @lucasrosa @rileythomp @pkramaric
+* @pkramaric @flybits/backend @flybits/front-end

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -83,7 +83,7 @@ runs:
           TAGS_DEV=$(echo "$response_body" | jq -r '.results[] | select(.name | endswith(".dev")) | .name')
 
           # Get all image tags that match the staging regex
-          TAGS_STAGING=$(echo "$response_body" | jq -r '.results[] | select(.name | test("-[a-f0-9]{7,10}$")) | .name')
+          TAGS_STAGING=$(echo "$response_body" | jq -r '.results[] | select(.name | test("[a-f0-9]{7,10}$")) | .name')
          
           # Get tags to delete from TAGS_DEV (skip the first N tags)
           TAGS_DEV_TO_DELETE=$(echo "$TAGS_DEV" | tail -n +$((KEEP_LATEST + 1)))

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -83,7 +83,7 @@ runs:
           TAGS_DEV=$(echo "$response_body" | jq -r '.results[] | select(.name | endswith(".dev")) | .name')
 
           # Get all image tags that match the staging regex
-          TAGS_STAGING=$(echo "$response_body" | jq -r '.results[] | select(.name | test("-[a-zA-Z0-9]{7}$|[a-zA-Z0-9]{7}(?!(.dev))")) | .name')
+          TAGS_STAGING=$(echo "$response_body" | jq -r '.results[] | select(.name | test("-[a-f0-9]{7,10}$")) | .name')
          
           # Get tags to delete from TAGS_DEV (skip the first N tags)
           TAGS_DEV_TO_DELETE=$(echo "$TAGS_DEV" | tail -n +$((KEEP_LATEST + 1)))

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -9,12 +9,12 @@ inputs:
     description: The password associated to the docker registry user
     required: true
   docker_repo:
-    description: The repository where the docker image should be saved. Format is {organization}/{repository}
+    description: The repository where the docker image should be saved. Format is {organization}/{repository}. Comma-separated for list of images to delete.
     required: true
   keep_latest:
     description: Keep the latest number of .dev images (how many should not be deleted)
     required: true
-    default: 10
+    default: 5
 
 runs:
   using: "composite"
@@ -48,79 +48,83 @@ runs:
         DOCKER_TOKEN: ${{ env.DOCKER_TOKEN }}
       run: |
         # Inputs
-        REPO="${{ inputs.docker_repo }}"
+        REPOS=(${${{ inputs.docker_repo }}}) # Split comma-separated string into an array
         KEEP_LATEST="${{ inputs.keep_latest }}"
 
-        echo "Cleaning up images for repository: $REPO"
-        CURRENT_PAGE=1
+        # Function to delete tags, handles errors
+        delete_tag() {
+          local TAG="$1"
+          local deleteUrl="https://hub.docker.com/v2/repositories/$REPO/tags/$TAG"
+          echo "Deleting tag: $TAG - $deleteUrl"
 
-        while true; do
-          
-          # Fetch all tags for the repository
-          url="https://hub.docker.com/v2/repositories/$REPO/tags?page=$CURRENT_PAGE&page_size=100"
-          echo "Fetching page $CURRENT_PAGE for tags in $REPO - $url"
+          response=$(curl -s -X DELETE -H "Authorization: Bearer $DOCKER_TOKEN" "$deleteUrl")
+          http_code=$(echo "$response" | head -n 1 | awk '{print $2}') # Extract HTTP code
 
-          # Get the response and the http code associated to the response
-          response=$(curl -s -H "Authorization: JWT $DOCKER_TOKEN" -o response.txt -w "%{http_code}" "$url")
-          
-          # Split the status code and response.
-          http_code="${response: -3}"
-          response_body=$(<response.txt)
-
-          # If status code is 404 it means we have reached the end of the list so we can exit the loop and the job will be completed
-          if [[ $http_code -eq 404 ]]; then
-            echo "Could not find object so most likely we have reached the end - $response_body ..."
-            break
-          fi
-
-          # If status code is not 200 exit ungracefully.
-          if [[ $http_code -ne 200 ]]; then
-            echo "Request failed - $response_body ..."
+          if [[ $http_code -ne 204 ]]; then
+            echo "Deleting $TAG Request failed $http_code ... $response"
             exit 1
           fi
+        }
 
-          # Get all image tags that end with .dev
-          TAGS_DEV=$(echo "$response_body" | jq -r '.results[] | select(.name | endswith(".dev")) | .name')
+        # Function to process tags for a given type (.dev or staging)
+        process_tags() {
+          local TAGS_JSON="$1"
+          local TAGS_TO_DELETE=$(echo "$TAGS_JSON" | jq -r '.results[] | .name' | sort | tail -n +$((KEEP_LATEST + 1))) # Sort before tail
 
-          # Get all image tags that match the staging regex
-          TAGS_STAGING=$(echo "$response_body" | jq -r '.results[] | select(.name | test("[a-f0-9]{7,10}$")) | .name')
-         
-          # Get tags to delete from TAGS_DEV (skip the first N tags)
-          TAGS_DEV_TO_DELETE=$(echo "$TAGS_DEV" | tail -n +$((KEEP_LATEST + 1)))
-
-          # Get tags to delete from TAGS_STAGING (skip the first N tags)
-          TAGS_STAGING_TO_DELETE=$(echo "$TAGS_STAGING" | tail -n +$((KEEP_LATEST + 1)))
-
-          # Combine the tags to delete from both lists
-          TAGS_TO_DELETE=$(echo -e "$TAGS_DEV_TO_DELETE\n$TAGS_STAGING_TO_DELETE")
-
-          # Loop through tags to delete
           for TAG in $TAGS_TO_DELETE; do
+            delete_tag "$TAG"
+          done
+        }
+
+        for REPO in "${REPOS[@]}"; do # Loop through each repository
+          echo "Cleaning up images for repository: $REPO"
+
+          CURRENT_PAGE=1
+          while true; do
             
-            deleteUrl=https://hub.docker.com/v2/repositories/$REPO/tags/$TAG
-            echo "Deleting tag: $TAG - $deleteUrl"
+            # Fetch all tags for the repository
+            url="https://hub.docker.com/v2/repositories/$REPO/tags?page=$CURRENT_PAGE&page_size=100"
+            echo "Fetching page $CURRENT_PAGE for tags in $REPO - $url"
+
+            # Get the response and the http code associated to the response
+            response=$(curl -s -H "Authorization: JWT $DOCKER_TOKEN" -o response.txt -w "%{http_code}" "$url")
             
-            response=$(curl -s -X DELETE -H "Authorization: Bearer $DOCKER_TOKEN" -o response.txt -w "%{http_code}" "$deleteUrl")
+            # Split the status code and response.
             http_code="${response: -3}"
-            
-            # If the response is not 204 it means that something went wrong and exit ungracefully
-            if [[ $http_code -ne 204 ]]; then
-              response_body=$(<response.txt)
-              echo "Deleting $TAG Request failed $http_code ... $response_body"
+            response_body=$(<response.txt)
+
+            # If status code is 404 it means we have reached the end of the list so we can exit the loop and the job will be completed
+            if [[ $http_code -eq 404 ]]; then
+              echo "Could not find object so most likely we have reached the end - $response_body ..."
+              break
+            fi
+
+            # If status code is not 200 exit ungracefully.
+            if [[ $http_code -ne 200 ]]; then
+              echo "Request failed - $response_body ..."
               exit 1
             fi
+
+            # Get all image tags that end with .dev
+            TAGS_DEV=$(echo "$response_body" | jq -r '.results[] | select(.name | endswith(".dev")) | .name')
+
+            # Get all image tags that match the staging regex
+            TAGS_STAGING=$(echo "$response_body" | jq -r '.results[] | select(.name | test("[a-f0-9]{7,10}$")) | .name')
+          
+            process_tags "$TAGS_DEV"
+            process_tags "$TAGS_STAGING"
+          
+            # If there are no more pages to iterate through exit the loop and the job should be completed successfully
+            if [[ "$(echo "$response" | jq -r '.next')" == "null" ]]; then # More reliable next page check
+              echo "Exiting paging loop for $REPO..."
+              break
+            fi
+
+            #Update pages and set KEEP_LATEST to 0 as for pages > 1 we do not want to keep any values
+            # this is not an issue because it is unlikely that we will have 100 items (the first page) with no .dev images
+            KEEP_LATEST=0
+            ((CURRENT_PAGE++))
           done
 
-          # If there are no more pages to iterate through exit the loop and the job should be completed successfully
-          if [[ "$next" == "null" ]]; then
-            echo "Exiting paging loop for $REPO..."
-            break
-          fi
-
-          #Update pages and set KEEP_LATEST to 0 as for pages > 1 we do not want to keep any values
-          # this is not an issue because it is unlikely that we will have 100 items (the first page) with no .dev images
-          KEEP_LATEST=0
-          ((CURRENT_PAGE++))
-        done
-
-        echo "Cleanup completed for repository: $REPO"
+          echo "Cleanup completed for repository: $REPO"
+        done # End of the repository loop

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -48,8 +48,8 @@ runs:
         DOCKER_TOKEN: ${{ env.DOCKER_TOKEN }}
       run: |
         # Inputs
-        REPOS=() # Initialize an empty array
-        IFS=',' read -r -a REPOS <<< "${{ inputs.docker_repo }}"  # Read into array, using comma as IFS
+        INPUTTED_REPOS="${{ inputs.docker_repo }}"
+        IFS=',' read -r -a REPOS <<< "$INPUTTED_REPOS"  # Read into array, using comma as IFS
 
         KEEP_LATEST="${{ inputs.keep_latest }}"
 

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -51,36 +51,10 @@ runs:
         INPUTTED_REPOS="${{ inputs.docker_repo }}"
         IFS=',' read -r -a REPOS <<< "$INPUTTED_REPOS"  # Read into array, using comma as IFS
 
-        KEEP_LATEST="${{ inputs.keep_latest }}"
-
-        # Function to delete tags, handles errors
-        delete_tag() {
-          local TAG="$1"
-          local deleteUrl="https://hub.docker.com/v2/repositories/$REPO/tags/$TAG"
-          echo "Deleting tag: $TAG - $deleteUrl"
-
-          response=$(curl -s -X DELETE -H "Authorization: Bearer $DOCKER_TOKEN" "$deleteUrl")
-          http_code=$(echo "$response" | head -n 1 | awk '{print $2}') # Extract HTTP code
-
-          if [[ $http_code -ne 204 ]]; then
-            echo "Deleting $TAG Request failed $http_code ... $response"
-            exit 1
-          fi
-        }
-
-        # Function to process tags for a given type (.dev or staging)
-        process_tags() {
-          local TAGS_JSON="$1"
-          local TAGS_TO_DELETE=$(echo "$TAGS_JSON" | jq -r '.results[] | .name' | sort | tail -n +$((KEEP_LATEST + 1))) # Sort before tail
-
-          for TAG in $TAGS_TO_DELETE; do
-            delete_tag "$TAG"
-          done
-        }
-
         for REPO in "${REPOS[@]}"; do # Loop through each repository
           echo "Cleaning up images for repository: $REPO"
 
+          KEEP_LATEST="${{ inputs.keep_latest }}"
           CURRENT_PAGE=1
           while true; do
             
@@ -113,11 +87,34 @@ runs:
             # Get all image tags that match the staging regex
             TAGS_STAGING=$(echo "$response_body" | jq -r '.results[] | select(.name | test("[a-f0-9]{7,10}$")) | .name')
           
-            process_tags "$TAGS_DEV"
-            process_tags "$TAGS_STAGING"
-          
+            # Get tags to delete from TAGS_DEV (skip the first N tags)
+            TAGS_DEV_TO_DELETE=$(echo "$TAGS_DEV" | tail -n +$((KEEP_LATEST + 1)))
+
+            # Get tags to delete from TAGS_STAGING (skip the first N tags)
+            TAGS_STAGING_TO_DELETE=$(echo "$TAGS_STAGING" | tail -n +$((KEEP_LATEST + 1)))
+
+            # Combine the tags to delete from both lists
+            TAGS_TO_DELETE=$(echo -e "$TAGS_DEV_TO_DELETE\n$TAGS_STAGING_TO_DELETE")
+
+            # Loop through tags to delete
+            for TAG in $TAGS_TO_DELETE; do
+
+              deleteUrl=https://hub.docker.com/v2/repositories/$REPO/tags/$TAG
+              echo "Deleting tag: $TAG - $deleteUrl"
+
+              response=$(curl -s -X DELETE -H "Authorization: Bearer $DOCKER_TOKEN" -o response.txt -w "%{http_code}" "$deleteUrl")
+              http_code="${response: -3}"
+
+              # If the response is not 204 it means that something went wrong and exit ungracefully
+              if [[ $http_code -ne 204 ]]; then
+                response_body=$(<response.txt)
+                echo "Deleting $TAG Request failed $http_code ... $response_body"
+                exit 1
+              fi
+            done
+
             # If there are no more pages to iterate through exit the loop and the job should be completed successfully
-            if [[ "$(echo "$response" | jq -r '.next')" == "null" ]]; then # More reliable next page check
+            if [[ "$next" == "null" ]]; then
               echo "Exiting paging loop for $REPO..."
               break
             fi

--- a/backend/clean-docker/action.yaml
+++ b/backend/clean-docker/action.yaml
@@ -48,7 +48,9 @@ runs:
         DOCKER_TOKEN: ${{ env.DOCKER_TOKEN }}
       run: |
         # Inputs
-        REPOS=(${${{ inputs.docker_repo }}}) # Split comma-separated string into an array
+        REPOS=() # Initialize an empty array
+        IFS=',' read -r -a REPOS <<< "${{ inputs.docker_repo }}"  # Read into array, using comma as IFS
+
         KEEP_LATEST="${{ inputs.keep_latest }}"
 
         # Function to delete tags, handles errors

--- a/backend/nightly/action.yaml
+++ b/backend/nightly/action.yaml
@@ -33,7 +33,7 @@ runs:
   steps:
 
     #Clean up docker images
-    - uses: flybits/actions/backend/clean-docker@ddc0935963a5d120f1171e928b76398c157063e2
+    - uses: flybits/actions/backend/clean-docker@640def8e4c88b885e2f5b25389bf26b39f8bae2e
       id: docker_cleanup
       with:
         docker_username: ${{ inputs.docker_username }}

--- a/backend/nightly/action.yaml
+++ b/backend/nightly/action.yaml
@@ -33,7 +33,7 @@ runs:
   steps:
 
     #Clean up docker images
-    - uses: flybits/actions/backend/clean-docker@640def8e4c88b885e2f5b25389bf26b39f8bae2e
+    - uses: flybits/actions/backend/clean-docker@main
       id: docker_cleanup
       with:
         docker_username: ${{ inputs.docker_username }}

--- a/backend/nightly/action.yaml
+++ b/backend/nightly/action.yaml
@@ -33,7 +33,7 @@ runs:
   steps:
 
     #Clean up docker images
-    - uses: flybits/actions/backend/clean-docker@main
+    - uses: flybits/actions/backend/clean-docker@ddc0935963a5d120f1171e928b76398c157063e2
       id: docker_cleanup
       with:
         docker_username: ${{ inputs.docker_username }}


### PR DESCRIPTION
<!--
  If this pull request addresses an issue, make sure your description includes "Resolves #xx", "Fixes #xx", or "Closes #xx".
  https://help.github.com/articles/closing-issues-using-keywords
-->

## Description
Proof of multiple repositories being deleted in one action; it should require a small change on workflow actions where the images need to be separated by commas. For example; docker_repo: flybits/auth,flybits/auth-user-deletion with no spaces

![Screenshot 2025-02-14 at 16 09 09](https://github.com/user-attachments/assets/0a356c2a-3e4e-43e0-8606-942c1459b3b6)


### Checklist

  - [ ] PR title is clear and describes the work
  - [ ] Commit messages are self-explanatory and summarize the change

### Action

  - [ ] Tests are provided/updated for the new/existing action
  - [ ] The action maintainer in `CODEOWNERS` is updated
  - [ ] The `README.md` file for new/existing action is created/updated
