### PR TITLE
Fix url being empty when pushed tag

### DIFF
--- a/frontend/slack/deploy-start/action.yml
+++ b/frontend/slack/deploy-start/action.yml
@@ -79,7 +79,7 @@ runs:
                   type: "plain_text"
                   text: "Commit"
                   emoji: true
-                url: "${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+                url: "${{ github.event.pull_request.html_url || github.event.head_commit.url || ${{ github.event.repository.html_url }}/releases/tag/${{ github.ref_name }}}}"
                 action_id: "button-action"
             - type: "context"
               elements:


### PR DESCRIPTION
<!--
  If this pull request addresses an issue, make sure your description includes "Resolves #xx", "Fixes #xx", or "Closes #xx".
  https://help.github.com/articles/closing-issues-using-keywords
-->


## Description
When the tag is pushed to the remote repository and triggers the workflow, both the variables `github.event.pull_request.html_url` and `github.event.head_commit.url` return empty values. As a result, the Slack job fails and throws the following error:

`Error: must be more than 0 characters [json-pointer:/blocks/4/accessory/url]`

### Checklist

  - [X] PR title is clear and describes the work
  - [X] Commit messages are self-explanatory and summarize the change

### Action

  - [ ] Tests are provided/updated for the new/existing action
  - [ ] The action maintainer in `CODEOWNERS` is updated
  - [ ] The `README.md` file for new/existing action is created/updated
