### PR TITLE
Use configuration Release instead of Debug

### DIFF
--- a/mobile/ios-deploy-app/action.yaml
+++ b/mobile/ios-deploy-app/action.yaml
@@ -186,7 +186,7 @@ runs:
         xcodebuild -scheme "${{ inputs.scheme }}" \
         -archivePath $RUNNER_TEMP/${{ inputs.xcarchive_path }} \
         -sdk iphoneos \
-        -configuration Debug \
+        -configuration Release \
         -destination generic/platform=iOS \
         clean archive          
 


### PR DESCRIPTION
<!--
  If this pull request addresses an issue, make sure your description includes "Resolves #xx", "Fixes #xx", or "Closes #xx".
  https://help.github.com/articles/closing-issues-using-keywords
-->

## Description
Current build workflow is using the debug configuration instead of release.
This PR intention is to use the Release configuration instead of Debug since we plan to put the app into App Store.

### Checklist

  - [x] PR title is clear and describes the work
  - [x] Commit messages are self-explanatory and summarize the change

### Action

  - [ ] Tests are provided/updated for the new/existing action
  - [ ] The action maintainer in `CODEOWNERS` is updated
  - [ ] The `README.md` file for new/existing action is created/updated
