### PR TITLE
[PET-000] chore(deps): update Go version in govulncheck action to 1.26.4

### DIFF
--- a/backend/go-vulncheck/action.yml
+++ b/backend/go-vulncheck/action.yml
@@ -27,7 +27,7 @@ runs:
     - uses: actions/setup-go@v6
       with:
         go-version-file: 'go.mod'
-        go-version: '1.26.3'
+        go-version: '1.26.4'
         check-latest: true
     - name: Configure git for private modules
       run: git config --global url."https://${{inputs.deployment_token}}@github.com".insteadOf "https://github.com"


### PR DESCRIPTION
Bumps the Go toolchain used by the govulncheck action to 1.26.4 to clear the stdlib vulnerability alerts in #alerts-govulncheck.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go build environment to version 1.26.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->