### PR TITLE
[PET-000] Add the ability to push to gitops-solutions via actions

### DIFF
--- a/backend/build/action.yaml
+++ b/backend/build/action.yaml
@@ -54,7 +54,14 @@ runs:
     - name: Update Version of Docker Image
       shell: bash
       run: |
+        if [[ ! -f VERSION ]]; then
+          echo "VERSION ERROR: VERSION file not found in repository root."
+          exit 1
+        fi
+
         VERSION=$(cat VERSION)
+        [[ "$VERSION" =~ ^[0-9]+.[0-9]+.[0-9]+-[0-9]$ ]] || { echo "VERSION FILE ERROR: INVALID FORMAT! Expected format: 1.2.3-0" ; exit 1; }
+
         if [[ ${{ inputs.type }} == "dev" ]]; then
           SUFFIX="-$(git rev-parse --short HEAD)"
           SUFFIX+=".dev"

--- a/backend/push/action.yaml
+++ b/backend/push/action.yaml
@@ -40,6 +40,9 @@ inputs:
       - dev
       - staging
       - production
+  project_name:
+    description: "GitOps Solutions project directory name under base/. Required when gitops_repo is gitops-solutions."
+    required: false
 
 runs:
   using: "composite"
@@ -67,6 +70,13 @@ runs:
 
           if [[ ${{ inputs.type }} == "production" || ${{ inputs.type }} == "staging" ]]; then
             [[ "${{ inputs.branch }}" =~ ^(main)$ ]] || { echo "BRANCH ERROR: This pipeline it's only available for main branch!" ; exit 1; }
+          fi
+        fi
+
+        if [[ "${{ inputs.gitops_repo }}" == "gitops-solutions" ]]; then
+          if [[ -z "${{ inputs.project_name }}" ]]; then
+            echo "PROJECT_NAME ERROR: project_name is required when deploying to gitops-solutions."
+            exit 1
           fi
         fi
 
@@ -213,9 +223,7 @@ runs:
         cd git
         git clone git@github.com:flybits/gitops-solutions.git .
 
-        PROJECT_NAME=$(echo "${{ inputs.docker_repo }}" | cut -d'/' -f2)
-        PROJECT_DIR="base/$PROJECT_NAME"
-
+        PROJECT_DIR="base/${{ inputs.project_name }}"
         echo "PROJECT_DIR: $PROJECT_DIR"
 
         if [ ! -f "$PROJECT_DIR/kustomization.yaml" ]; then

--- a/backend/push/action.yaml
+++ b/backend/push/action.yaml
@@ -130,6 +130,8 @@ runs:
       env:
         SSH_AUTH_SOCK: /tmp/ssh_agent.sock
       run: |
+        source "${{ github.action_path }}/scripts/try_commit_push.sh"
+
         echo "IMAGE: $TAG"
         
         git config --global user.name "flybitsbot"
@@ -141,51 +143,7 @@ runs:
         
         update_image_and_push () {
           kustomize edit set image $TAG
-
-          try_commit_push () {
-            if [ -z "$(git status --porcelain)" ]; then
-              echo "No changes detected after kustomize edit. Image tag $TAG is already set correctly in GitOps. Nothing to commit."
-              return 0
-            fi
-
-            git add . # Stage all changes, including the kustomize modification
-            git commit -m "Auto-release $TAG" || { echo "Commit failed. Exiting."; return 1; }
-
-            # Every service pipeline writes gitops main, so a rejected push is normal
-            # under load rather than an error. Sleep first and rebase immediately before
-            # the retry: rebasing and then sleeping leaves the refreshed base stale for
-            # the whole sleep, so the next push is rejected again at any real concurrency.
-            MAX_ATTEMPTS=10
-            pushed=false
-            for i in $(seq 1 $MAX_ATTEMPTS); do
-              echo "Attempting to push (attempt $i/$MAX_ATTEMPTS)..."
-              if git push origin $BRANCH; then
-                echo "Upload Success"
-                pushed=true
-                break
-              fi
-
-              SLEEP_TIME=$((RANDOM % 6 + 2))  # 2-7s, jittered so runners do not retry in lockstep
-              echo "Push rejected, retrying in $SLEEP_TIME seconds..."
-              sleep $SLEEP_TIME
-
-              echo "Rebasing onto latest origin/$BRANCH..."
-              if ! git pull --rebase origin $BRANCH; then
-                echo "ERROR: rebase failed for $TAG. GitOps was NOT updated."
-                git rebase --abort || true
-                return 1
-              fi
-            done
-
-            # Without this the loop falls through on exhaustion and the step exits 0,
-            # reporting success while the Auto-release commit is discarded with the runner.
-            if [ "$pushed" != true ]; then
-              echo "ERROR: exhausted $MAX_ATTEMPTS push attempts for $TAG. GitOps was NOT updated."
-              return 1
-            fi
-          }
-
-          try_commit_push || exit 1
+          try_commit_push "$TAG" "$BRANCH" "GitOps" 10 || exit 1
         }
         
         BRANCH=main

--- a/backend/push/action.yaml
+++ b/backend/push/action.yaml
@@ -195,3 +195,36 @@ runs:
         fi
 
         update_image_and_push
+
+    #Push To GitOps Solutions
+    - name: Push To GitOps Solutions
+      if: inputs.gitops_repo == 'gitops-solutions'
+      shell: bash
+      env:
+        SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+      run: |
+        source "${{ github.action_path }}/scripts/try_commit_push.sh"
+
+        echo "IMAGE: $TAG"
+        
+        git config --global user.name "flybitsbot"
+        git config --global user.email "dev@flybits.com"
+        
+        mkdir git
+        cd git
+        git clone git@github.com:flybits/gitops-solutions.git .
+
+        PROJECT_NAME=$(echo "${{ inputs.docker_repo }}" | cut -d'/' -f2)
+        PROJECT_DIR="base/$PROJECT_NAME"
+
+        echo "PROJECT_DIR: $PROJECT_DIR"
+
+        if [ ! -f "$PROJECT_DIR/kustomization.yaml" ]; then
+          echo "ERROR: Kustomization file not found at $PROJECT_DIR/kustomization.yaml"
+          exit 1
+        fi
+
+        echo "Updating image in $PROJECT_DIR..."
+        cd "$PROJECT_DIR"
+        kustomize edit set image $TAG
+        try_commit_push "$TAG" "main" "GitOps Solutions" 4 || exit 1

--- a/backend/push/action.yaml
+++ b/backend/push/action.yaml
@@ -27,9 +27,16 @@ inputs:
   branch:
     description: Which branch is running the job
     required: true
+  gitops_repo:
+    description: "Target GitOps repository for deployment"
+    required: false
+    default: gitops
+    options:
+      - gitops
+      - gitops-solutions
   type:
-    description: "Which server are we deploying to"
-    required: true
+    description: "Which server are we deploying to. Required when gitops_repo is gitops."
+    required: false
     options:
       - dev
       - staging
@@ -48,8 +55,20 @@ runs:
     - name: Inputs validation
       shell: bash
       run: |
-        if [[ ${{ inputs.type }} == "production" || ${{ inputs.type }} == "staging" ]]; then
-          [[ "${{ inputs.branch }}" =~ ^(main)$ ]] || { echo "BRANCH ERROR: This pipeline it's only available for main branch!" ; exit 1; }
+        if [[ "${{ inputs.gitops_repo }}" != "gitops" && "${{ inputs.gitops_repo }}" != "gitops-solutions" ]]; then
+          echo "GITOPS_REPO ERROR: Unrecognized gitops_repo '${{ inputs.gitops_repo }}'. Must be 'gitops' or 'gitops-solutions'."
+          exit 1
+        fi
+
+        if [[ "${{ inputs.gitops_repo }}" == "gitops" ]]; then
+          if [[ -z "${{ inputs.type }}" ]]; then
+            echo "TYPE ERROR: type is required when deploying to gitops."
+            exit 1
+          fi
+
+          if [[ ${{ inputs.type }} == "production" || ${{ inputs.type }} == "staging" ]]; then
+            [[ "${{ inputs.branch }}" =~ ^(main)$ ]] || { echo "BRANCH ERROR: This pipeline it's only available for main branch!" ; exit 1; }
+          fi
         fi
 
     #Setup SSH Keys

--- a/backend/push/action.yaml
+++ b/backend/push/action.yaml
@@ -1,6 +1,5 @@
-name: Run Unit Tests
-author: Petar Kramaric
-description: GitHub action for building backend docker images
+name: Push Docker Image to GitOps
+description: GitHub action for pushing docker images to GitOps repositories
 inputs:
   github_token:
     description: A GitHub personal access token with repo scope to access private repositories.

--- a/backend/push/action.yaml
+++ b/backend/push/action.yaml
@@ -125,6 +125,7 @@ runs:
 
     #Push To GitOps
     - name: Push To GitOps
+      if: inputs.gitops_repo == 'gitops'
       shell: bash
       env:
         SSH_AUTH_SOCK: /tmp/ssh_agent.sock
@@ -231,8 +232,8 @@ runs:
 
         # unrecognized tag
         else
-          echo "ERROR: Unrecognized tag $TAG. Skipping"
-          exit 0
+          echo "ERROR: Unrecognized type ${{ inputs.type }}. Skipping"
+          exit 1
         fi
 
         update_image_and_push

--- a/backend/push/scripts/try_commit_push.sh
+++ b/backend/push/scripts/try_commit_push.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+try_commit_push() {
+  local tag="$1"
+  local branch="$2"
+  local repo_label="$3"
+  local max_attempts="$4"
+
+  if [ -z "$(git status --porcelain)" ]; then
+    echo "No changes detected after kustomize edit. Image tag $tag is already set correctly in $repo_label. Nothing to commit."
+    return 0
+  fi
+
+  git add .
+  git commit -m "Auto-release $tag" || { echo "Commit failed. Exiting."; return 1; }
+
+  # Every service pipeline writes to the same GitOps branch, so a rejected push is
+  # normal under load rather than an error. Sleep first and rebase immediately before
+  # the retry: rebasing and then sleeping leaves the refreshed base stale for the
+  # whole sleep, so the next push is rejected again at any real concurrency.
+  local pushed=false
+
+  for i in $(seq 1 "$max_attempts"); do
+    echo "Attempting to push (attempt $i/$max_attempts)..."
+    if git push origin "$branch"; then
+      echo "Upload Success"
+      pushed=true
+      break
+    fi
+
+    local sleep_time=$((RANDOM % 6 + 2))  # 2-7s, jittered so runners do not retry in lockstep
+    echo "Push rejected, retrying in $sleep_time seconds..."
+    sleep "$sleep_time"
+
+    echo "Rebasing onto latest origin/$branch..."
+    if ! git pull --rebase origin "$branch"; then
+      echo "ERROR: rebase failed for $tag. $repo_label was NOT updated."
+      git rebase --abort || true
+      return 1
+    fi
+  done
+
+  # Without this the loop falls through on exhaustion and the step exits 0,
+  # reporting success while the Auto-release commit is discarded with the runner.
+  if [ "$pushed" != true ]; then
+    echo "ERROR: exhausted $max_attempts push attempts for $tag. $repo_label was NOT updated."
+    return 1
+  fi
+}


### PR DESCRIPTION
## Description

Updates the deployment flow so you can push to either gitops or gitops-solutions. The default behaviour is to use gitops so we shouldn't have to update any of the existing backend repositories. 🤞 

### Checklist

  - [ ] PR title is clear and describes the work
  - [ ] Commit messages are self-explanatory and summarize the change

### Action

  - [ ] Tests are provided/updated for the new/existing action
  - [ ] The action maintainer in `CODEOWNERS` is updated
  - [ ] The `README.md` file for new/existing action is created/updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for pushing Docker image updates to GitOps or GitOps Solutions repositories.
  * Introduced new workflow inputs to select the target repository and, for Solutions, specify the project name.
  * Added shared push behavior that creates an automated release commit and retries failed pushes.
* **Bug Fixes**
  * Workflows now validate that the required version file exists and matches the expected semantic version format before proceeding.
  * Improved input and configuration validation, and now fails on unrecognized configuration instead of proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->