### PR TITLE
fix(backend): allow VERSION with or without -0 suffix

### DIFF
--- a/backend/build/action.yaml
+++ b/backend/build/action.yaml
@@ -60,7 +60,7 @@ runs:
         fi
 
         VERSION=$(cat VERSION)
-        [[ "$VERSION" =~ ^[0-9]+.[0-9]+.[0-9]+-[0-9]$ ]] || { echo "VERSION FILE ERROR: INVALID FORMAT! Expected format: 1.2.3-0" ; exit 1; }
+        [[ "$VERSION" =~ ^[0-9]+.[0-9]+.[0-9]+(-0)?$ ]] || { echo "VERSION FILE ERROR: INVALID FORMAT! Expected format: 1.2.3 or 1.2.3-0" ; exit 1; }
 
         if [[ ${{ inputs.type }} == "dev" ]]; then
           SUFFIX="-$(git rev-parse --short HEAD)"

--- a/backend/deployment/action.yml
+++ b/backend/deployment/action.yml
@@ -40,7 +40,7 @@ runs:
         [[ "${{ inputs.who_trigger }}" ]] || { echo "who_trigger input is empty" ; exit 1; }
         [[ "${{ inputs.version }}" =~ ^(patch|minor|major)$ ]] || { echo "VERSION ERROR: ${{ inputs.version }} isn't a valid value" ; exit 1; }
         [[ "${{ inputs.branch }}" =~ ^(main)$ ]] || { echo "BRANCH ERROR: This pipeline it's only available for main branch!" ; exit 1; }
-        [[ "$current_version" =~ ^[0-9]+.[0-9]+.[0-9]+-[0-9]$ ]] || { echo "VERSION FILE ERROR: INVALID FORMAT!" ; exit 1; }
+        [[ "$current_version" =~ ^[0-9]+.[0-9]+.[0-9]+(-0)?$ ]] || { echo "VERSION FILE ERROR: INVALID FORMAT! Expected format: 1.2.3 or 1.2.3-0" ; exit 1; }
     - name: Bump version major-minor
       uses: HardNorth/github-version-generate@v1.4.0
       if: inputs.version != 'patch'


### PR DESCRIPTION
## Description

Accept both x.y.z and x.y.z-0 in build and deployment validation so released versions like 1.20.5 no longer fail CI after deployment.

### Checklist

  - [ ] PR title is clear and describes the work
  - [ ] Commit messages are self-explanatory and summarize the change

### Action

  - [ ] Tests are provided/updated for the new/existing action
  - [ ] The action maintainer in `CODEOWNERS` is updated
  - [ ] The `README.md` file for new/existing action is created/updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Version format validation is now more flexible, accepting both standard and prerelease version formats for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->