### PR TITLE
[PET-000] Bump govulncheck Go to 1.26.6

### DIFF
--- a/backend/go-vulncheck/action.yml
+++ b/backend/go-vulncheck/action.yml
@@ -27,7 +27,7 @@ runs:
     - uses: actions/setup-go@v7
       with:
         go-version-file: 'go.mod'
-        go-version: '1.26.5'
+        go-version: '1.26.6'
         check-latest: true
     - name: Configure git for private modules
       run: git config --global url."https://${{inputs.deployment_token}}@github.com".insteadOf "https://github.com"


### PR DESCRIPTION
## Summary
- Pin `backend/go-vulncheck` setup-go to **1.26.6** so scans pick up the stdlib fixes for GO-2026-6218 / related advisories.

## Why
`rules` (and others) fail Govulncheck on PRs while the runner stays on 1.26.5.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go setup action to use Go version 1.26.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->