### PR TITLE
[PET-000] update Go version in govulncheck action to 1.26.6

### DIFF
--- a/backend/go-vulncheck/action.yml
+++ b/backend/go-vulncheck/action.yml
@@ -27,7 +27,7 @@ runs:
     - uses: actions/setup-go@v7
       with:
         go-version-file: 'go.mod'
-        go-version: '1.26.5'
+        go-version: '1.26.6'
         check-latest: true
     - name: Configure git for private modules
       run: git config --global url."https://${{inputs.deployment_token}}@github.com".insteadOf "https://github.com"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain used by the vulnerability-check workflow to version 1.26.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->